### PR TITLE
Set up molecule testing

### DIFF
--- a/.github/workflows/molecule-provision.yml
+++ b/.github/workflows/molecule-provision.yml
@@ -1,0 +1,39 @@
+name: Test provision
+on:
+  pull_request:
+    paths:
+      - "roles/provision/**"
+
+jobs:
+  molecule:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        scenario:
+          - centos7
+    env:
+      MOLECULE_RUN_TAGS: provision
+      PY_COLORS: 1
+      ANSIBLE_FORCE_COLOR: 1
+    steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v4
+        with:
+          path: ansible_collections/mirsg/xnat
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Install test dependencies
+        run: |
+          sudo apt-get update && sudo apt-get -y install rsync
+          python3 -m pip install --upgrade pip
+          python3 -m pip install ansible molecule molecule-plugins[docker] docker requests
+
+      - name: Test with molecule
+        run: |
+          cd ansible_collections/mirsg/xnat/tests
+          molecule test --scenario-name  "${{ matrix.scenario }}"

--- a/.github/workflows/molecule-provision.yml
+++ b/.github/workflows/molecule-provision.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check out the codebase
         uses: actions/checkout@v4
         with:
-          path: ansible_collections/mirsg/xnat
+          path: ansible_collections/mirsg/infrastructure
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -35,5 +35,5 @@ jobs:
 
       - name: Test with molecule
         run: |
-          cd ansible_collections/mirsg/xnat/tests
+          cd ansible_collections/mirsg/infrastructure/tests
           molecule test --scenario-name  "${{ matrix.scenario }}"

--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -1,0 +1,7 @@
+---
+collections:
+  - community.general
+  - ansible.posix
+  - community.postgresql
+  - community.docker
+  - community.crypto

--- a/roles/provision/tasks/Rocky.yml
+++ b/roles/provision/tasks/Rocky.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install the ca-certificates package
+- name: Ensure the ca-certificates package is installed
   become: true
   ansible.builtin.yum:
     name: "ca-certificates"

--- a/tests/molecule/centos7/molecule.yml
+++ b/tests/molecule/centos7/molecule.yml
@@ -71,7 +71,6 @@ provisioner:
   config_options:
     defaults:
       callbacks_enabled: profile_tasks, timer, yaml
-      vault_password_file: "${MOLECULE_SCENARIO_DIRECTORY}/../resources/.vault_password"
     tags:
       run: ${MOLECULE_RUN_TAGS:-all}
   inventory:

--- a/tests/molecule/centos7/molecule.yml
+++ b/tests/molecule/centos7/molecule.yml
@@ -1,0 +1,94 @@
+---
+dependency:
+  name: galaxy
+  options:
+    force: true
+    role-file: "${MOLECULE_SCENARIO_DIRECTORY}/../../../meta/requirements.yml"
+    requirements-file: "${MOLECULE_SCENARIO_DIRECTORY}/../../../meta/requirements.yml"
+
+driver:
+  name: docker
+
+platforms:
+  - name: molecule_db
+    hostname: molecule.db.local
+    image: ${MOLECULE_DOCKER_IMAGE:-geerlingguy/docker-centos7-ansible:latest}
+    required: true
+    command: ""
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: ${MOLECULE_PRE_BUILD_IMAGE:-true}
+    volumes:
+      - ./molecule-data:/storage/molecule
+    keep_volumes: false
+    groups:
+      - all
+      - db
+      - centos7
+    docker_networks:
+      - name: molecule
+        ipam_config:
+          - subnet: "192.168.56.0/24"
+            gateway: "192.168.56.1"
+    networks:
+      - name: molecule
+        ipv4_address: "192.168.56.2"
+    exposed_ports:
+      - "5432"
+    etc_hosts:
+      molecule.web.local: "192.168.56.3"
+
+  - name: molecule_web
+    hostname: molecule.web.local
+    image: ${MOLECULE_DOCKER_IMAGE:-geerlingguy/docker-centos7-ansible:latest}
+    required: true
+    command: ""
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+    volumes:
+      - ./molecule-data:/storage/molecule
+    keep_volumes: false
+    groups:
+      - all
+      - web
+      - centos7
+    networks:
+      - name: molecule
+        ipv4_address: "192.168.56.3"
+    exposed_ports:
+      - "80"
+      - "443"
+      - "8080"
+    published_ports:
+      - 127.0.0.1:8080:8080
+    etc_hosts:
+      molecule.db.local: "192.168.56.2"
+
+provisioner:
+  name: ansible
+  log: true
+  config_options:
+    defaults:
+      callbacks_enabled: profile_tasks, timer, yaml
+      vault_password_file: "${MOLECULE_SCENARIO_DIRECTORY}/../resources/.vault_password"
+    tags:
+      run: ${MOLECULE_RUN_TAGS:-all}
+  inventory:
+    links:
+      hosts: ../resources/inventory/hosts.yml
+      group_vars: ../resources/inventory/group_vars/
+  playbooks:
+    converge: ../resources/converge.yml
+  env:
+    ANSIBLE_VERBOSITY: "1"
+
+verifier:
+  name: ansible
+  env:
+    ANSIBLE_VERBOSITY: "1"
+
+lint: |
+  set -e
+  yamllint .
+  ansible-lint .

--- a/tests/molecule/centos7/molecule.yml
+++ b/tests/molecule/centos7/molecule.yml
@@ -10,8 +10,8 @@ driver:
   name: docker
 
 platforms:
-  - name: molecule_db
-    hostname: molecule.db.local
+  - name: instance
+    hostname: molecule.instnace.local
     image: ${MOLECULE_DOCKER_IMAGE:-geerlingguy/docker-centos7-ansible:latest}
     required: true
     command: ""
@@ -23,7 +23,7 @@ platforms:
     keep_volumes: false
     groups:
       - all
-      - db
+      - molecule
       - centos7
     docker_networks:
       - name: molecule
@@ -33,37 +33,6 @@ platforms:
     networks:
       - name: molecule
         ipv4_address: "192.168.56.2"
-    exposed_ports:
-      - "5432"
-    etc_hosts:
-      molecule.web.local: "192.168.56.3"
-
-  - name: molecule_web
-    hostname: molecule.web.local
-    image: ${MOLECULE_DOCKER_IMAGE:-geerlingguy/docker-centos7-ansible:latest}
-    required: true
-    command: ""
-    cgroupns_mode: host
-    privileged: true
-    pre_build_image: true
-    volumes:
-      - ./molecule-data:/storage/molecule
-    keep_volumes: false
-    groups:
-      - all
-      - web
-      - centos7
-    networks:
-      - name: molecule
-        ipv4_address: "192.168.56.3"
-    exposed_ports:
-      - "80"
-      - "443"
-      - "8080"
-    published_ports:
-      - 127.0.0.1:8080:8080
-    etc_hosts:
-      molecule.db.local: "192.168.56.2"
 
 provisioner:
   name: ansible

--- a/tests/molecule/resources/converge.yml
+++ b/tests/molecule/resources/converge.yml
@@ -1,0 +1,10 @@
+---
+- name: Provision infrastructure
+  hosts: all
+  become: true
+  gather_facts: true
+  roles:
+    - role: mirsg.infrastructure.provision
+      tags: provision
+    - role: mirsg.infrastructure.install_python
+      tags: python

--- a/tests/molecule/resources/inventory/group_vars/all.yml
+++ b/tests/molecule/resources/inventory/group_vars/all.yml
@@ -1,0 +1,5 @@
+---
+EXTERNAL_STORAGE_DRIVE: "/storage/molecule"
+
+# mirsg.infrastructure.provision
+server_locale: "en_GB.UTF-8"

--- a/tests/molecule/resources/inventory/hosts.yml
+++ b/tests/molecule/resources/inventory/hosts.yml
@@ -1,0 +1,27 @@
+---
+all:
+  # List of all servers, defining their alias and IP (hostname)
+  hosts:
+    # Host for your database server. Variables in host_vars/molecule_db will be available to this host
+    molecule_db:
+      hostname: "molecule.db.local"
+      ansible_ip: "192.168.56.2"
+      ansible_port: 22
+    # Host for your web server. Variables in host_vars/molecule_web will be available to this host
+    molecule_web:
+      hostname: "molecule..web.local"
+      ansible_ip: "192.168.56.3"
+      ansible_port: 22
+
+  # Ansible groups. Groups allow configuration and variables to be shared between hosts
+  # Variables in group_vars/all will be shared between all hosts
+  children:
+    # All PostgreSQL servers. Variables in group_vars/db will be shared between these hosts
+    db:
+      hosts:
+        molecule_db:
+
+    # All the web (XNAT/Tomcat) servers. Variables in group_vars/web will be shared between these hosts
+    web:
+      hosts:
+        molecule_web:

--- a/tests/molecule/resources/inventory/hosts.yml
+++ b/tests/molecule/resources/inventory/hosts.yml
@@ -2,26 +2,16 @@
 all:
   # List of all servers, defining their alias and IP (hostname)
   hosts:
-    # Host for your database server. Variables in host_vars/molecule_db will be available to this host
-    molecule_db:
-      hostname: "molecule.db.local"
+    # Host for your database server. Variables in host_vars/instance will be available to this host
+    instance:
+      hostname: "molecule.instance.local"
       ansible_ip: "192.168.56.2"
-      ansible_port: 22
-    # Host for your web server. Variables in host_vars/molecule_web will be available to this host
-    molecule_web:
-      hostname: "molecule..web.local"
-      ansible_ip: "192.168.56.3"
       ansible_port: 22
 
   # Ansible groups. Groups allow configuration and variables to be shared between hosts
   # Variables in group_vars/all will be shared between all hosts
   children:
-    # All PostgreSQL servers. Variables in group_vars/db will be shared between these hosts
-    db:
+    # All molecule servers. Variables in group_vars/molecule will be shared between these hosts
+    molecule:
       hosts:
-        molecule_db:
-
-    # All the web (XNAT/Tomcat) servers. Variables in group_vars/web will be shared between these hosts
-    web:
-      hosts:
-        molecule_web:
+        instance:


### PR DESCRIPTION
- Add a `centos7` molecule scenario (`tests/molecule/centos7/molecule.yml`) - it has two instances, one for a database and another for a web server
- Add an inventory for testing (`tests/molecule/resources/inventory/hosts.yml`)
- Add group vars for testing (`tests/molecule/resources/inventory/group_vars/all.yml`)
- Add a converge playbook for testing (`tests/molecule/resources/converge.yml`). This playbook uses tags to limit which roles are included. This means we can run molecule only on roles that have changed in a given pr.
- Add a workflow to run molecule on `mirsg.infrastructure.provision` when the provision role has changed
- Add a requirements file so we can install this collection

Edit: @drmatthews after talking offline, we'll use a single instance for running molecule tests rather than two (database + web server)