### PR TITLE
Add molecule setup for `mirsg.infrastructure.install_python`

### DIFF
--- a/.github/workflows/molecule-python.yml
+++ b/.github/workflows/molecule-python.yml
@@ -1,0 +1,13 @@
+name: Test Python
+on:
+  pull_request:
+    paths:
+      - "roles/install_python/**"
+      - ".github/workflows/molecule.yml"
+      - ".github/workflows/molecule-python.yml"
+
+jobs:
+  molecule-firewalld:
+    uses: ./.github/workflows/molecule.yml
+    with:
+      run-tags: python

--- a/roles/install_python/README.md
+++ b/roles/install_python/README.md
@@ -1,11 +1,7 @@
-# Ansible Role: mirsg.install_python
+# Ansible Role: mirsg.infrastructure.install_python
 
 This role installs Python, pip, and setuptools on Debian and RedHat operating systems. It will also update pip to the latest version or a
 user-specified version, and then install user-specified Python packages using pip.
-
-## Requirements
-
-If you would like to run Ansible Molecule to test this role, the requirements are in [`requirements.txt`](https://github.com/UCL-MIRSG/ansible-role-install-python/blob/main/requirements.txt).
 
 ## Role Variables
 
@@ -29,10 +25,6 @@ The packages listed in `install_python.system_packages` will be installed by the
 
 `pip_packages`: list of Python packages to be installed by pip. This defaults to `[]`.
 
-## Dependencies
-
-There are no Ansible-Galaxy dependencies for this role.
-
 ## Example Playbook
 
 This role will install Python on a managed host. To used this role, add it to the list of roles in a play:
@@ -43,11 +35,3 @@ This role will install Python on a managed host. To used this role, add it to th
   roles:
     - mirsg.install_python
 ```
-
-## License
-
-[BSD 3-Clause License](https://github.com/UCL-MIRSG/ansible-role-install-python/blob/main/LICENSE).
-
-## Author Information
-
-This role was created by the [Medical Imaging Research Software Group](https://www.ucl.ac.uk/advanced-research-computing/expertise/research-software-development/medical-imaging-research-software-group) at [UCL](https://www.ucl.ac.uk/).

--- a/tests/molecule/resources/inventory/group_vars/all.yml
+++ b/tests/molecule/resources/inventory/group_vars/all.yml
@@ -5,6 +5,18 @@ selinux_enabled: false
 # mirsg.infrastructure.provision
 server_locale: "en_GB.UTF-8"
 
+# mirsg.infrastructure.install_python
+install_python:
+  version: "2"
+  pip_version: "20.3.4"
+  pip_executable: "pip"
+  system_packages:
+    - python
+    - python-pip
+    - python-setuptools
+  pip_packages:
+    - cryptography
+
 # mirsg.infrastructure.firewalld
 allow_public_access: true
 internal_zone_open_services:


### PR DESCRIPTION
- update README to reflect the role is now part of a collection
- add molecule inventory group vars fro `mirsg.infrastructure.install_python`
- add a workflow to run molecule on `install_python` when the role changes