### PR TITLE
Add playbook to setup user accounts

### DIFF
--- a/.github/workflows/molecule-provision_accounts.yml
+++ b/.github/workflows/molecule-provision_accounts.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "roles/provision_accounts/**"
+      - "playbooks/setup_user_accounts.yml"
       - ".github/workflows/molecule.yml"
       - ".github/workflows/molecule-provision_accounts.yml"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/UCL-MIRSG/.github
-    rev: v0.36.0
+    rev: v0.38.0
     hooks:
       - id: mirsg-hooks

--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@ configure infrastructure for deploying XNAT and OMERO.
 
 ### Playbooks
 
-| Name                                                         | Description                                                |
-| ------------------------------------------------------------ | ---------------------------------------------------------- |
-| [setup_user_accounts.yml](playbooks/setup_user_accounts.yml) | Create OS user accounts a group of servers `target`, which |
-| defaults to `all`.                                           |
+| Name                                                         | Description                                                                   |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| [setup_user_accounts.yml](playbooks/setup_user_accounts.yml) | Create OS user accounts a group of servers `target`, which defaults to `all`. |
 
 ## External requirements
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 This repository contains the `mirsg.infrastructure` Ansible Collection. This collection can be used to
 configure infrastructure for deploying XNAT and OMERO.
 
+## Included content
+
+### Playbooks
+
+| Name                                                         | Description                                                |
+| ------------------------------------------------------------ | ---------------------------------------------------------- |
+| [setup_user_accounts.yml](playbooks/setup_user_accounts.yml) | Create OS user accounts a group of servers `target`, which |
+| defaults to `all`.                                           |
+
 ## External requirements
 
 Before using this collection and its playbooks, you must install the
@@ -27,8 +36,8 @@ collections:
 ## Testing this collection
 
 We use [Ansible Molecule](https://ansible.readthedocs.io/projects/molecule/) and its
-[Docker plugin](https://github.com/ansible-community/molecule-plugins) to test the roles in
-this collection.
+[Docker plugin](https://github.com/ansible-community/molecule-plugins) to test the roles
+and playbooks in this collection.
 
 If you would like to run the tests locally you will need to:
 

--- a/playbooks/setup_user_accounts.yml
+++ b/playbooks/setup_user_accounts.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create user accounts on all servers
+- name: Create user accounts on targeted servers
   hosts: "{{ target | default('all') }}"
   become: true
   become_user: root

--- a/playbooks/setup_user_accounts.yml
+++ b/playbooks/setup_user_accounts.yml
@@ -1,0 +1,10 @@
+---
+- name: Create user accounts on all servers
+  hosts: "{{ target | default('all') }}"
+  become: true
+  become_user: root
+  become_method: ansible.builtin.sudo
+  gather_facts: true
+
+  roles:
+    - role: provision_accounts

--- a/roles/provision_accounts/tasks/main.yml
+++ b/roles/provision_accounts/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
 # tasks file for provision_accounts
-
 - name: Create OS user accounts from variables
   ansible.builtin.user:
     user: "{{ item.username }}"

--- a/tests/molecule/resources/converge.yml
+++ b/tests/molecule/resources/converge.yml
@@ -7,9 +7,6 @@
     - role: mirsg.infrastructure.provision
       tags: provision
 
-    - role: mirsg.infrastructure.provision_accounts
-      tags: provision_accounts
-
     - role: mirsg.infrastructure.install_python
       tags: python
 
@@ -18,3 +15,7 @@
 
     - role: mirsg.infrastructure.postgresql
       tags: postgresql
+
+- name: Provision infrastructure with playbooks
+  ansible.builtin.import_playbook: mirsg.infrastructure.setup_user_accounts
+  tags: provision_accounts


### PR DESCRIPTION
- add `playbooks/setup_user_accounts.yml` playbook
- uses the role `provision_accounts` to setup OS users
- update README with brief description of the playbook
- test the `provision_accounts` role via this playbook