### PR TITLE
Fix collection install

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You can also include it in a `requirements.yml` file and install it via
 collections:
   - name: mirsg.infrastructure
     source: https://github.com/UCL-MIRSG/ansible-collection-infra.git
+    type: git
     version: main
 ```
 


### PR DESCRIPTION
Without this, I cannot get it to install `main`. Moving forwards, we will probably want to specify `vx.y.z`, but for now let's fix this.