### PR TITLE
Additional alerting rules

### DIFF
--- a/roles/monitoring_server/defaults/main.yml
+++ b/roles/monitoring_server/defaults/main.yml
@@ -38,7 +38,7 @@ monitoring_server_alertmanager:
   external_data_dir: "{{ monitoring_server_storage_root }}/alertmanager"
   volume: /alertmanager
   commandline_args:
-    web.external-url: "https://{{ ansible_host }}/alertmanager/"
+    web.external-url: "https://{{ monitoring_server_hostname }}/alertmanager/"
     storage.path: /alertmanager/data
     config.file: /alertmanager/alertmanager.yml
 

--- a/roles/monitoring_server/tasks/install_alertmanager_container.yml
+++ b/roles/monitoring_server/tasks/install_alertmanager_container.yml
@@ -21,11 +21,7 @@
     image: "{{ monitoring_server_alertmanager.image }}"
     state: started
     user: "{{ monitoring_server_uid }}:{{ monitoring_server_gid }}"
-    command: >
-      "{% for key in
-      monitoring_server_alertmanager.commandline_args
-      %}--{{ key }}={{ monitoring_server_alertmanager.commandline_args[key] }}
-      {% endfor %}"
+    command: "{% for key in monitoring_server_alertmanager.commandline_args %}--{{ key }}={{ monitoring_server_alertmanager.commandline_args[key] }}{% endfor %}" # noqa yaml[line-length]
     networks:
       - name: monitor-net
     volumes:

--- a/roles/monitoring_server/tasks/install_alertmanager_container.yml
+++ b/roles/monitoring_server/tasks/install_alertmanager_container.yml
@@ -21,7 +21,11 @@
     image: "{{ monitoring_server_alertmanager.image }}"
     state: started
     user: "{{ monitoring_server_uid }}:{{ monitoring_server_gid }}"
-    command: "{% for key in monitoring_server_alertmanager.commandline_args %}--{{ key }}={{ monitoring_server_alertmanager.commandline_args[key] }} {% endfor %}" # noqa yaml[line-length]
+    command: >-
+      "{% for key in
+      monitoring_server_alertmanager.commandline_args
+      %}--{{ key }}={{ monitoring_server_alertmanager.commandline_args[key] }}
+      {% endfor %}"
     networks:
       - name: monitor-net
     volumes:

--- a/roles/monitoring_server/tasks/install_alertmanager_container.yml
+++ b/roles/monitoring_server/tasks/install_alertmanager_container.yml
@@ -21,7 +21,7 @@
     image: "{{ monitoring_server_alertmanager.image }}"
     state: started
     user: "{{ monitoring_server_uid }}:{{ monitoring_server_gid }}"
-    command: "{% for key in monitoring_server_alertmanager.commandline_args %}--{{ key }}={{ monitoring_server_alertmanager.commandline_args[key] }}{% endfor %}" # noqa yaml[line-length]
+    command: "{% for key in monitoring_server_alertmanager.commandline_args %}--{{ key }}={{ monitoring_server_alertmanager.commandline_args[key] }} {% endfor %}" # noqa yaml[line-length]
     networks:
       - name: monitor-net
     volumes:

--- a/roles/monitoring_server/tasks/install_alertmanager_container.yml
+++ b/roles/monitoring_server/tasks/install_alertmanager_container.yml
@@ -14,18 +14,15 @@
     owner: root
     mode: "0644"
 
-- name: Start alertmanager container # noqa jinja[spacing]
+- name: Start alertmanager container
   community.docker.docker_container:
     name: "{{ monitoring_server_alertmanager.container_name }}"
     hostname: "{{ monitoring_server_alertmanager.container_name }}"
     image: "{{ monitoring_server_alertmanager.image }}"
     state: started
     user: "{{ monitoring_server_uid }}:{{ monitoring_server_gid }}"
-    command: >-
-      "{% for key in
-      monitoring_server_alertmanager.commandline_args
-      -%}--{{ key }}={{ monitoring_server_alertmanager.commandline_args[key] }}
-      {%- endfor %}"
+    command: "{% for key in monitoring_server_alertmanager.commandline_args %}\
+      --{{ key }}={{ monitoring_server_alertmanager.commandline_args[key] }} {% endfor %}"
     networks:
       - name: monitor-net
     volumes:

--- a/roles/monitoring_server/tasks/install_alertmanager_container.yml
+++ b/roles/monitoring_server/tasks/install_alertmanager_container.yml
@@ -14,7 +14,7 @@
     owner: root
     mode: "0644"
 
-- name: Start alertmanager container
+- name: Start alertmanager container # noqa jinja[spacing]
   community.docker.docker_container:
     name: "{{ monitoring_server_alertmanager.container_name }}"
     hostname: "{{ monitoring_server_alertmanager.container_name }}"
@@ -24,8 +24,8 @@
     command: >-
       "{% for key in
       monitoring_server_alertmanager.commandline_args
-      %}--{{ key }}={{ monitoring_server_alertmanager.commandline_args[key] }}
-      {% endfor %}"
+      -%}--{{ key }}={{ monitoring_server_alertmanager.commandline_args[key] }}
+      {%- endfor %}"
     networks:
       - name: monitor-net
     volumes:

--- a/roles/monitoring_server/templates/prometheus_rules.yml.j2
+++ b/roles/monitoring_server/templates/prometheus_rules.yml.j2
@@ -30,15 +30,6 @@ groups:
 
   - name: metrics
     rules:
-      - alert: InodeUsageHigh
-        expr: 100 - node_filesystem_files_free/node_filesystem_files*100 > 80
-        for: 0m
-        labels:
-          severity: warning
-        annotations:
-          summary: Instance inode usage high (Instance:{{ $labels.instance }})
-          description: "The used file nodes(inodes) of the filesystem(filesystem:{{ $labels.mountpoint }}) is more than 80%, value: {{ $labels.value }}%"
-
       - alert: MemoryUsageHigh
         expr: 100- node_memory_MemAvailable_bytes/node_memory_MemTotal_bytes*100 > 80
         for: 5m
@@ -56,3 +47,21 @@ groups:
         annotations:
           summary: Instance cpu load high (Instance:{{ $labels.instance }})
           description: "Instance cpu load more than 80% within 5 minutes, value: {{ $labels.value }}%"
+
+      - alert: FilesystemFull
+        expr: 100 - node_filesystem_free_bytes{mountpoint!~"/*|/boot.*|/run.*"}/node_filesystem_size_bytes*100 > 90
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Instance filestore disk space low (Instance:{{ $labels.instance }})
+          description: "The used space of the mounted filestore (mountpoint:{{ $labels.mountpoint }}) is more than 90%, value: {{ $labels.value }}%"
+
+      - alert: InodeUsageHigh
+        expr: 100 - node_filesystem_files_free/node_filesystem_files*100 > 80
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: Instance inode usage high (Instance:{{ $labels.instance }})
+          description: "The used file nodes(inodes) of the filesystem(filesystem:{{ $labels.mountpoint }}) is more than 80%, value: {{ $labels.value }}%"

--- a/roles/monitoring_server/templates/prometheus_rules.yml.j2
+++ b/roles/monitoring_server/templates/prometheus_rules.yml.j2
@@ -9,6 +9,16 @@ groups:
         annotations:
           description: "TLS certificate will expire in {{ $value | humanizeDuration }} (instance {{ $labels.instance }})"
 
+  - name: endpoint-down
+    rules:
+      - alert: EndpointDown
+        expr: probe_success == 0
+        for: 1m
+        labels:
+          severity: "critical"
+        annotations:
+          summary: "Endpoint {{ $labels.instance }} down"
+
   - name: vm-down-detector
     rules:
       - alert: InstanceDown
@@ -20,12 +30,13 @@ groups:
           summary: "{{ $labels.job }} instance {{ $labels.instance }} down"
           description: "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes."
 
-  - name: endpoint-down
+  - name: high-inode-usage
     rules:
-      - alert: EndpointDown
-        expr: probe_success == 0
-        for: 1m
+      - alert: NodeInodeUsageHigh
+        expr: 100 - node_filesystem_files_free/node_filesystem_files*100 > 80
+        for: 0m
         labels:
-          severity: "critical"
+          severity: warning
         annotations:
-          summary: "Endpoint {{ $labels.instance }} down"
+          summary: Instance inode usage high (Instance:{{ $labels.instance }})
+          description: "The used file nodes(inodes) of the filesystem(filesystem:{{ $labels.mountpoint }}) is more than 80%，value: {{ $labels.value }}%"

--- a/roles/monitoring_server/templates/prometheus_rules.yml.j2
+++ b/roles/monitoring_server/templates/prometheus_rules.yml.j2
@@ -15,7 +15,7 @@ groups:
         expr: probe_success == 0
         for: 1m
         labels:
-          severity: "critical"
+          severity: critical
         annotations:
           summary: "Endpoint {{ $labels.instance }} down"
 
@@ -30,7 +30,7 @@ groups:
 
   - name: metrics
     rules:
-      - alert: NodeInodeUsageHigh
+      - alert: InodeUsageHigh
         expr: 100 - node_filesystem_files_free/node_filesystem_files*100 > 80
         for: 0m
         labels:
@@ -39,20 +39,20 @@ groups:
           summary: Instance inode usage high (Instance:{{ $labels.instance }})
           description: "The used file nodes(inodes) of the filesystem(filesystem:{{ $labels.mountpoint }}) is more than 80%, value: {{ $labels.value }}%"
 
-      - alert: NodeMemoryUsageHigh
+      - alert: MemoryUsageHigh
         expr: 100- node_memory_MemAvailable_bytes/node_memory_MemTotal_bytes*100 > 80
         for: 5m
         labels:
           severity: warning
         annotations:
-          summary: Node memory usage high (Instance:{{ $labels.instance }})
-          description: "Node memory usage more than 80% within 5 minutus, value:{{ $labels.value }}%"
+          summary: Instance memory usage high (Instance:{{ $labels.instance }})
+          description: "Instance memory usage more than 80% within 5 minutus, value:{{ $labels.value }}%"
 
-      - alert: NodeCpuLoadHigh
+      - alert: CpuLoadHigh
         expr: 100 - avg by(instance)(rate(node_cpu_seconds_total{mode="idle"}[5m]))*100 > 80
         for: 0m
         labels:
           severity: warning
         annotations:
-          summary: Node cpu load high (Instance:{{ $labels.instance }})
-          description: "Node cpu load more than 80% within 5 minutes, value: {{ $labels.value }}%"
+          summary: Instance cpu load high (Instance:{{ $labels.instance }})
+          description: "Instance cpu load more than 80% within 5 minutes, value: {{ $labels.value }}%"

--- a/roles/monitoring_server/templates/prometheus_rules.yml.j2
+++ b/roles/monitoring_server/templates/prometheus_rules.yml.j2
@@ -9,7 +9,7 @@ groups:
         annotations:
           description: "TLS certificate will expire in {{ $value | humanizeDuration }} (instance {{ $labels.instance }})"
 
-  - name: down-detector
+  - name: vm-down-detector
     rules:
       - alert: InstanceDown
         expr: up == 0
@@ -19,3 +19,13 @@ groups:
         annotations:
           summary: "{{ $labels.job }} instance {{ $labels.instance }} down"
           description: "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes."
+
+  - name: endpoint-down
+    rules:
+      - alert: EndpointDown
+        expr: probe_success == 0
+        for: 1m
+        labels:
+          severity: "critical"
+        annotations:
+          summary: "Endpoint {{ $labels.instance }} down"

--- a/roles/monitoring_server/templates/prometheus_rules.yml.j2
+++ b/roles/monitoring_server/templates/prometheus_rules.yml.j2
@@ -40,19 +40,19 @@ groups:
           description: "The used file nodes(inodes) of the filesystem(filesystem:{{ $labels.mountpoint }}) is more than 80%, value: {{ $labels.value }}%"
 
       - alert: NodeMemoryUsageHigh
-        expr: 100- node_memory_MemAvailable_bytes/node_memory_MemTotal_bytes*100 > 70
+        expr: 100- node_memory_MemAvailable_bytes/node_memory_MemTotal_bytes*100 > 80
         for: 5m
         labels:
           severity: warning
         annotations:
           summary: Node memory usage high (Instance:{{ $labels.instance }})
-          description: "Node memory usage more than 70% within 5 minutus, value:{{ $labels.value }}%"
+          description: "Node memory usage more than 80% within 5 minutus, value:{{ $labels.value }}%"
 
       - alert: NodeCpuLoadHigh
-            expr: 100 - avg by(instance)(rate(node_cpu_seconds_total{mode="idle"}[5m]))*100 > 70
-            for: 0m
-            labels:
-              severity: warning
-            annotations:
-              summary: Node cpu load high (Instance:{{ $labels.instance }})
-              description: "Node cpu load more than 70% within 5 minutes, value: {{ $labels.value }}%"
+        expr: 100 - avg by(instance)(rate(node_cpu_seconds_total{mode="idle"}[5m]))*100 > 80
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: Node cpu load high (Instance:{{ $labels.instance }})
+          description: "Node cpu load more than 80% within 5 minutes, value: {{ $labels.value }}%"

--- a/roles/monitoring_server/templates/prometheus_rules.yml.j2
+++ b/roles/monitoring_server/templates/prometheus_rules.yml.j2
@@ -30,7 +30,7 @@ groups:
           summary: "{{ $labels.job }} instance {{ $labels.instance }} down"
           description: "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes."
 
-  - name: high-inode-usage
+  - name: metrics
     rules:
       - alert: NodeInodeUsageHigh
         expr: 100 - node_filesystem_files_free/node_filesystem_files*100 > 80
@@ -39,4 +39,22 @@ groups:
           severity: warning
         annotations:
           summary: Instance inode usage high (Instance:{{ $labels.instance }})
-          description: "The used file nodes(inodes) of the filesystem(filesystem:{{ $labels.mountpoint }}) is more than 80%，value: {{ $labels.value }}%"
+          description: "The used file nodes(inodes) of the filesystem(filesystem:{{ $labels.mountpoint }}) is more than 80%, value: {{ $labels.value }}%"
+
+      - alert: NodeMemoryUsageHigh
+        expr: 100- node_memory_MemAvailable_bytes/node_memory_MemTotal_bytes*100 > 70
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Node memory usage high (Instance:{{ $labels.instance }})
+          description: "Node memory usage more than 70% within 5 minutus, value:{{ $labels.value }}%"
+
+      - alert: NodeCpuLoadHigh
+            expr: 100 - avg by(instance)(rate(node_cpu_seconds_total{mode="idle"}[5m]))*100 > 70
+            for: 0m
+            labels:
+              severity: warning
+            annotations:
+              summary: Node cpu load high (Instance:{{ $labels.instance }})
+              description: "Node cpu load more than 70% within 5 minutes, value: {{ $labels.value }}%"

--- a/roles/monitoring_server/templates/prometheus_rules.yml.j2
+++ b/roles/monitoring_server/templates/prometheus_rules.yml.j2
@@ -9,7 +9,7 @@ groups:
         annotations:
           description: "TLS certificate will expire in {{ $value | humanizeDuration }} (instance {{ $labels.instance }})"
 
-  - name: endpoint-down
+  - name: down-detector
     rules:
       - alert: EndpointDown
         expr: probe_success == 0
@@ -19,8 +19,6 @@ groups:
         annotations:
           summary: "Endpoint {{ $labels.instance }} down"
 
-  - name: vm-down-detector
-    rules:
       - alert: InstanceDown
         expr: up == 0
         for: 5m


### PR DESCRIPTION
Changes:

- Add an `EndPointDown` alert to the `down-detector` group
- Add alerting for high inode, memory and CPU usage.

These have been tested on `ucl_test` with `mirsg_linux` as the monitoring host. Alerts can be seen at https://mirsg-linux.cs.ucl.ac.uk/prometheus/alerts