### PR TITLE
Use bcrypt with password_hash

### DIFF
--- a/roles/monitoring_client/templates/node_exporter_web.yml.j2
+++ b/roles/monitoring_client/templates/node_exporter_web.yml.j2
@@ -2,4 +2,4 @@ tls_server_config:
   cert_file: node_exporter.crt
   key_file: node_exporter.key
 basic_auth_users:
-  {{ monitoring_client_exporter_username }}: {{ monitoring_client_exporter_password | password_hash }}
+  {{ monitoring_client_exporter_username }}: {{ monitoring_client_exporter_password | password_hash('bcrypt') }}


### PR DESCRIPTION
Changes:

- Reinstate the `bcrypt` option for `password_hash`

This has been done since `node_exporter` expects hashed password for basic authentication to be created with `brypt`. I initially removed because the following appears when running the `monitoring_client` role:

```
AttributeError: module 'bcrypt' has no attribute '__about__'
```

The play proceeds and `node_exporter` is correctly installed. I tried pinning `bcrypt` to `4.0.1` as suggested in https://github.com/pyca/bcrypt/issues/684 but the traceback still appears. Without `bcrypt` the `node_exporter` service fails to start.

