### PR TITLE
Only copy PG cert to server when postgresql_use_ssl

### DIFF
--- a/roles/xnat/tasks/main.yml
+++ b/roles/xnat/tasks/main.yml
@@ -17,6 +17,7 @@
     owner: "{{ postgresql_client_ssl_certificate.owner }}"
     group: "{{ postgresql_client_ssl_certificate.group }}"
     mode: "0600"
+  when: postgresql_use_ssl
 
 - name: "Configure XNAT directories"
   ansible.builtin.include_tasks: directories.yml

--- a/tests/molecule/resources/install_xnat/inventory/group_vars/web.yml
+++ b/tests/molecule/resources/install_xnat/inventory/group_vars/web.yml
@@ -21,4 +21,4 @@ firewalld_public_zone_ports:
 # Some times the default admin account hasn't finished creating even after tomcat has started
 # Add a delay here to give the admin account a chance to be created
 # Note, this issue only seems to happen in CI
-xnat_wait_for_tomcat: 10
+xnat_wait_for_tomcat: 15


### PR DESCRIPTION
Currently the XNAT role always attempts to copy to PG cert from the cache:
https://github.com/UCL-MIRSG/ansible-collection-infra/blob/b5385d78380444da7c10516c4e0e15bc5a7964ea/roles/xnat/tasks/main.yml#L13-L19

This should only be done if `postgresql_use_ssl` is `true`