### PR TITLE
install node exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ collection can be used to configure infrastructure for deploying XNAT and OMERO.
 
 ### Playbooks
 
-| Name                                                         | Description                                                                   |
-| ------------------------------------------------------------ | ----------------------------------------------------------------------------- |
-| [setup_user_accounts.yml](playbooks/setup_user_accounts.yml) | Create OS user accounts a group of servers `target`, which defaults to `all`. |
-| [install_monitoring.yml](playbooks/install_monitoring.yml)   | Configure a host to collect metrics from client machines.                     |
+| Name                                                                               | Description                                                                   |
+| ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [setup_user_accounts.yml](playbooks/setup_user_accounts.yml)                       | Create OS user accounts a group of servers `target`, which defaults to `all`. |
+| [install_monitoring.yml](playbooks/install_monitoring.yml)                         | Configure a host to collect metrics from client machines.                     |
+| [install_xnat.yml](playbooks/install_xnat.yml)                                     | Install XNAT on two-tier infrastructure.                                      |
+| [install_xnat_container_service.yml](playbooks/install_xnat_container_service.yml) | Install XNAT Container service (Docker host and client).                      |
 
 ## External requirements
 

--- a/roles/monitoring_client/defaults/main.yml
+++ b/roles/monitoring_client/defaults/main.yml
@@ -5,8 +5,10 @@ monitoring_client_node_exporter_binary:
   "https://github.com/prometheus/node_exporter/releases/download/v\
   {{ monitoring_client_node_exporter_version }}/node_exporter-\
   {{ monitoring_client_node_exporter_version }}.linux-amd64.tar.gz"
+monitoring_client_node_exporter_download_dir: "/tmp/node_exporter-{{ monitoring_client_node_exporter_version }}"
 monitoring_client_node_exporter_install_dir: /usr/bin/node_exporter
-monitoring_client_node_exporter_service: /etc/systemd/system/node_exporter.service
+monitoring_client_node_export_service_name: node_exporter.service
+monitoring_client_node_exporter_service: "/etc/systemd/system/{{ monitoring_client_node_export_service_name }}"
 monitoring_client_node_exporter_web_config: /usr/bin/node_exporter/web.yml
 monitoring_client_node_exporter_port: 9100
 monitoring_client_node_exporter_ssl_key: /usr/bin/node_exporter/node_exporter.key

--- a/roles/monitoring_client/tasks/install_node_exporter.yml
+++ b/roles/monitoring_client/tasks/install_node_exporter.yml
@@ -1,4 +1,12 @@
 ---
+- name: Create Node exporter download folder
+  ansible.builtin.file:
+    owner: "{{ monitoring_client_owner }}"
+    group: "{{ monitoring_client_group }}"
+    path: "{{ monitoring_client_node_exporter_download_dir }}"
+    state: directory
+    mode: "0777"
+
 - name: Create Node exporter folder
   ansible.builtin.file:
     owner: "{{ monitoring_client_owner }}"
@@ -10,12 +18,21 @@
 - name: Download and unarchive node_exporter
   ansible.builtin.unarchive:
     src: "{{ monitoring_client_node_exporter_binary }}"
-    dest: "{{ monitoring_client_node_exporter_install_dir }}"
+    dest: "{{ monitoring_client_node_exporter_download_dir }}"
     remote_src: true
     owner: "{{ monitoring_client_owner }}"
     group: "{{ monitoring_client_group }}"
     extra_opts: "--strip-components=1"
-    creates: "{{ monitoring_client_node_exporter_install_dir }}/node_exporter"
+    # creates: "{{ monitoring_client_node_exporter_download_dir }}/node_exporter"
+
+- name: Copy node_exporter binary to install location
+  ansible.builtin.copy:
+    src: "{{ monitoring_client_node_exporter_download_dir }}/node_exporter"
+    dest: "{{ monitoring_client_node_exporter_install_dir }}/node_exporter"
+    remote_src: true
+    owner: "{{ monitoring_client_owner }}"
+    group: "{{ monitoring_client_group }}"
+    mode: "0755"
 
 - name: Copy monitoring client crt and key files to node_exporter folder
   ansible.builtin.copy:

--- a/tests/molecule/resources/monitoring/verify.yml
+++ b/tests/molecule/resources/monitoring/verify.yml
@@ -1,4 +1,5 @@
-- name: Monitoring verify
+---
+- name: Check monitoring host
   hosts: monitoring_host
   become: true
   gather_facts: true
@@ -38,3 +39,16 @@
         name: "{{ monitoring_server_prometheus.container_name }}"
       register: result
       failed_when: "'exists' not in result.exists"
+
+- name: Check monitoring client
+  hosts: monitoring_client
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Populate service facts
+      ansible.builtin.service_facts:
+
+    - name: Ensure that node exporter has started
+      ansible.builtin.assert:
+        that:
+          - monitoring_client_node_export_service_name in ansible_facts.services


### PR DESCRIPTION
Changes:

Instead of using `ansible.builtin.unarchive` to pull and inflate the node exporter binary, which is skipped when the destination folder already exists, add a task to download the binary to a temporary location and a task for copying into place.