### PR TITLE
Make `firewalld` not block connections on both VMs

### DIFF
--- a/playbooks/molecule/resources/xnat/inventory/group_vars/all/all.yml
+++ b/playbooks/molecule/resources/xnat/inventory/group_vars/all/all.yml
@@ -6,6 +6,10 @@
 # For local testing (non-production), use 2096 to speed up deployment.
 diffie_helman_size_bits: 2048
 
+# mirsg.infrastructure.firewalld
+firewalld_internal_zone_sources:
+  - "{{ xnat_web_server.subnet | default(xnat_web_server.ip + '/32') }}"
+
 # Support for ipv6
 ipv6_enabled: false
 

--- a/playbooks/molecule/resources/xnat/inventory/group_vars/db.yml
+++ b/playbooks/molecule/resources/xnat/inventory/group_vars/db.yml
@@ -1,7 +1,3 @@
 ---
-# mirsg.infrastructure.firewalld
-firewalld_internal_zone_sources:
-  - "{{ xnat_web_server.subnet | default(xnat_web_server.ip + '/32') }}"
-
 firewalld_internal_zone_open_services:
   - "postgresql"


### PR DESCRIPTION
I've had to do this in UCL-MIRSG/UCLH-MPBE-SRR-XNAT#183, for it to work. Any reason not to?

Not sure if you’d want it in `all.yml`/`common.yml`/`server.yml`

After the playbook finishes it blocks access to the `xnat-web` container meaning you cannot run the playbook twice.