### PR TITLE
Run `molecule test` on `install_xnat` playbook

### DIFF
--- a/.github/workflows/molecule-install-xnat.yml
+++ b/.github/workflows/molecule-install-xnat.yml
@@ -43,4 +43,4 @@ jobs:
       - name: Test with molecule
         run: |
           cd ansible_collections/mirsg/infrastructure/playbooks
-          molecule converge --scenario-name  "${{ matrix.scenario }}"
+          molecule test --scenario-name  "${{ matrix.scenario }}"

--- a/playbooks/molecule/centos7_xnat/molecule.yml
+++ b/playbooks/molecule/centos7_xnat/molecule.yml
@@ -20,6 +20,7 @@ platforms:
     pre_build_image: true
     volumes:
       - ./xnat-data:/storage/xnat
+      - ${MOLECULE_SCENARIO_DIRECTORY}/../resources/xnat/files/resolv.conf:/etc/resolv.conf
     keep_volumes: false
     groups:
       - all
@@ -50,6 +51,7 @@ platforms:
     pre_build_image: true
     volumes:
       - ./xnat-data:/storage/xnat
+      - ${MOLECULE_SCENARIO_DIRECTORY}/../resources/xnat/files/resolv.conf:/etc/resolv.conf
     keep_volumes: false
     groups:
       - all
@@ -82,6 +84,7 @@ platforms:
     pre_build_image: true
     volumes:
       - ./xnat-data:/storage/xnat
+      - ${MOLECULE_SCENARIO_DIRECTORY}/../resources/xnat/files/resolv.conf:/etc/resolv.conf
     keep_volumes: false
     groups:
       - all

--- a/playbooks/molecule/resources/xnat/files/resolv.conf
+++ b/playbooks/molecule/resources/xnat/files/resolv.conf
@@ -1,0 +1,2 @@
+nameserver 8.8.8.8
+nameserver 8.8.4.4

--- a/playbooks/molecule/rocky9_xnat/molecule.yml
+++ b/playbooks/molecule/rocky9_xnat/molecule.yml
@@ -21,6 +21,7 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
       - ./xnat-data:/storage/xnat
+      - ${MOLECULE_SCENARIO_DIRECTORY}/../resources/xnat/files/resolv.conf:/etc/resolv.conf
     keep_volumes: false
     groups:
       - all
@@ -52,6 +53,7 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
       - ./xnat-data:/storage/xnat
+      - ${MOLECULE_SCENARIO_DIRECTORY}/../resources/xnat/files/resolv.conf:/etc/resolv.conf
     keep_volumes: false
     groups:
       - all
@@ -85,6 +87,7 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
       - ./xnat-data:/storage/xnat
+      - ${MOLECULE_SCENARIO_DIRECTORY}/../resources/xnat/files/resolv.conf:/etc/resolv.conf
     keep_volumes: false
     groups:
       - all


### PR DESCRIPTION
- run `molecule test` on `mirsg.infrastructure.install_xnat` playbook. This is to check that the playbook can be run twice without failure, and for idempotency checks
- update the `centos7_xnat` scenario to set the `/etc/resolv.conf` for the containers. This defines nameservers for the containers, which for some reason was necessary if we also use firewalld (otherwise the containers can't reach the internet after firewalld is started)
- update the `rocky9_xnat` scenario to set the `/etc/resolv.conf` for the containers. For some reason, this is not necessary locally but is required for the tests to pass in CI