### PR TITLE
Make `site_name` valid

### DIFF
--- a/playbooks/molecule/resources/xnat/inventory/group_vars/all/server.yml
+++ b/playbooks/molecule/resources/xnat/inventory/group_vars/all/server.yml
@@ -28,6 +28,6 @@ ssl:
 
 # XNAT configuration
 xnat_config:
-  site_name: "MIRSG XNAT"
-  site_description: "<h1>MIRSG XNAT</h1><p>A test instance of XNAT."
+  site_name: MIRSG_XNAT
+  site_description: <h1>MIRSG XNAT</h1><p>A test instance of XNAT.
   admin_password: "{{ vault_admin_password }}"


### PR DESCRIPTION
> The id used to refer to this site (also used to generate database ids). The Site ID must start with a letter and contain only letters, numbers and underscores. No spaces or non-alphanumeric characters.

Note, this does not address #76, but at least makes the `site_name` here valid according to XNAT.