### PR TITLE
`xnat_web_server.url` should include the exposed port

### DIFF
--- a/playbooks/molecule/resources/xnat/inventory/group_vars/all/server.yml
+++ b/playbooks/molecule/resources/xnat/inventory/group_vars/all/server.yml
@@ -4,7 +4,7 @@ external_storage_drive: "/storage/xnat"
 # web server VM
 xnat_web_server:
   host: "{{ hostvars['xnat_web']['hostname'] }}"
-  url: "http://{{ hostvars['xnat_web']['hostname'] }}:8000"
+  url: "http://{{ hostvars['xnat_web']['hostname'] }}:80"
   subnet: "192.168.56.0/24"
   ip: "{{ hostvars['xnat_web']['ansible_ip'] }}"
   storage_dir: "{{ external_storage_drive }}/data"


### PR DESCRIPTION
Fixes #75. Would be nice to do this as a variable, but not sure how easy that would be to do. Essentially the same change as in UCL-MIRSG/UCLH-MPBE-SRR-XNAT#198.