### PR TITLE
Fix running `install_xnat` in molecule test environment

### DIFF
--- a/playbooks/molecule/centos7_xnat/molecule.yml
+++ b/playbooks/molecule/centos7_xnat/molecule.yml
@@ -64,7 +64,6 @@ platforms:
       - name: xnat
         ipv4_address: 192.168.56.3
     exposed_ports:
-      - 22
       - 80
       - 443
       - 8080

--- a/playbooks/molecule/centos7_xnat/molecule.yml
+++ b/playbooks/molecule/centos7_xnat/molecule.yml
@@ -64,12 +64,13 @@ platforms:
       - name: xnat
         ipv4_address: 192.168.56.3
     exposed_ports:
+      - 22
       - 80
       - 443
       - 8080
       - 8104
     published_ports:
-      - 127.0.0.1:8000:80
+      - 127.0.0.1:8080:80
     etc_hosts:
       xnat.db.local: 192.168.56.2
       xnat.cserv.local: 192.168.56.4

--- a/playbooks/molecule/resources/xnat/inventory/group_vars/all/server.yml
+++ b/playbooks/molecule/resources/xnat/inventory/group_vars/all/server.yml
@@ -2,9 +2,14 @@
 external_storage_drive: "/storage/xnat"
 
 # web server VM
+# URL is localhost:8080
+# Inside the Docker network, 8080 is the Tomcat port
+# Outside the Docker network, 8080 maps to 80 (HTTP) on the web container
+# This is necessary to allow redirects when accessing the WEB UI outside the
+# Docker network, and to avoid CORS issues inside the network
 xnat_web_server:
   host: "{{ hostvars['xnat_web']['hostname'] }}"
-  url: "http://{{ hostvars['xnat_web']['hostname'] }}"
+  url: "http://{{ hostvars['xnat_web']['hostname'] }}:8080"
   subnet: "192.168.56.0/24"
   ip: "{{ hostvars['xnat_web']['ansible_ip'] }}"
   storage_dir: "{{ external_storage_drive }}/data"

--- a/playbooks/molecule/resources/xnat/inventory/hosts.yml
+++ b/playbooks/molecule/resources/xnat/inventory/hosts.yml
@@ -9,7 +9,7 @@ all:
       ansible_port: 22
     # Host for your web server. Variables in host_vars/xnat_web will be available to this host
     xnat_web:
-      hostname: "xnat.web.local"
+      hostname: "localhost" # necessary to allow redirects outside the Docker network and to avoid CORS issues inside the network
       ansible_ip: "192.168.56.3"
       ansible_port: 22
     # Host for running the container service. Variables in host_vars/xnat_cserv will be available to this host

--- a/playbooks/molecule/resources/xnat/verify.yml
+++ b/playbooks/molecule/resources/xnat/verify.yml
@@ -4,7 +4,7 @@
   tasks:
     - name: Get server status
       ansible.builtin.uri:
-        url: http://localhost:8000
+        url: http://localhost:8080
         method: GET
         validate_certs: false
         return_content: true

--- a/playbooks/molecule/rocky9_xnat/molecule.yml
+++ b/playbooks/molecule/rocky9_xnat/molecule.yml
@@ -43,7 +43,7 @@ platforms:
       xnat.cserv.local: 192.168.56.4
 
   - name: xnat_web
-    hostname: localhost # necessary to allow redirects outside the Docker network and to avoid CORS issues inside the network
+    hostname: xnat.web.local # other containers on the network use this hostname for connecting
     image: rockylinux/rockylinux:9-ubi-init
     required: true
     command: ""

--- a/playbooks/molecule/rocky9_xnat/molecule.yml
+++ b/playbooks/molecule/rocky9_xnat/molecule.yml
@@ -43,7 +43,7 @@ platforms:
       xnat.cserv.local: 192.168.56.4
 
   - name: xnat_web
-    hostname: xnat.web.local
+    hostname: localhost # necessary to allow redirects outside the Docker network and to avoid CORS issues inside the network
     image: rockylinux/rockylinux:9-ubi-init
     required: true
     command: ""
@@ -71,7 +71,7 @@ platforms:
       - 8080
       - 8104
     published_ports:
-      - 127.0.0.1:8000:80
+      - 127.0.0.1:8080:80
     etc_hosts:
       xnat.db.local: 192.168.56.2
       xnat.cserv.local: 192.168.56.4

--- a/playbooks/molecule/rocky9_xnat/molecule.yml
+++ b/playbooks/molecule/rocky9_xnat/molecule.yml
@@ -43,7 +43,7 @@ platforms:
       xnat.cserv.local: 192.168.56.4
 
   - name: xnat_web
-    hostname: xnat.web.local # other containers on the network use this hostname for connecting
+    hostname: xnat.web.local
     image: rockylinux/rockylinux:9-ubi-init
     required: true
     command: ""


### PR DESCRIPTION
Fixes https://github.com/UCL-MIRSG/ansible-collection-infra/issues/75

- fix test of `install_xnat` playbook
  - rename `xnat.web.local` to `localhost` for the web container
  - and use port 8080 for accessing port 80 on the web container from outside the network

