### PR TITLE
Add task to validate `xnat_config.site_name`

### DIFF
--- a/roles/xnat/tasks/settings_files.yml
+++ b/roles/xnat/tasks/settings_files.yml
@@ -9,7 +9,7 @@
     force: true
   notify: Restart tomcat
 
-- name: Validate xnat_config.site_name: {{ xnat_config.site_name }}
+- name: "Validate xnat_config.site_name: {{ xnat_config.site_name }}"
   ansible.builtin.assert:
     that:
       - xnat_config.site_name is match('^[A-Za-z][A-Za-z0-9_]*$')

--- a/roles/xnat/tasks/settings_files.yml
+++ b/roles/xnat/tasks/settings_files.yml
@@ -9,14 +9,14 @@
     force: true
   notify: Restart tomcat
 
-- name: "Validate xnat_config.site_name: {{ xnat_config.site_name }}"
+- name: Validate xnat_config.site_name: {{ xnat_config.site_name }}
   ansible.builtin.assert:
     that:
       - xnat_config.site_name is match('^[A-Za-z][A-Za-z0-9_]*$')
     fail_msg: >
       xnat_config.site_name must start with a letter and contain only
       letters, numbers, and underscores
-    success_msg: "xnat_config.site_name is valid"
+    success_msg: xnat_config.site_name is valid
 
 - name: "Configure prefs-init"
   ansible.builtin.template:

--- a/roles/xnat/tasks/settings_files.yml
+++ b/roles/xnat/tasks/settings_files.yml
@@ -13,7 +13,9 @@
   ansible.builtin.assert:
     that:
       - xnat_config.site_name is match('^[A-Za-z][A-Za-z0-9_]*$')
-    fail_msg: "xnat_config.site_name must start with a letter and contain only letters, numbers, and underscores"
+    fail_msg: >
+      xnat_config.site_name must start with a letter and contain only
+      letters, numbers, and underscores
     success_msg: "xnat_config.site_name is valid"
 
 - name: "Configure prefs-init"

--- a/roles/xnat/tasks/settings_files.yml
+++ b/roles/xnat/tasks/settings_files.yml
@@ -9,6 +9,13 @@
     force: true
   notify: Restart tomcat
 
+- name: "Validate xnat_config.site_name: {{ xnat_config.site_name }}"
+  ansible.builtin.assert:
+    that:
+      - xnat_config.site_name is match('^[A-Za-z][A-Za-z0-9_]*$')
+    fail_msg: "xnat_config.site_name must start with a letter and contain only letters, numbers, and underscores"
+    success_msg: "xnat_config.site_name is valid"
+
 - name: "Configure prefs-init"
   ansible.builtin.template:
     src: "prefs-init.j2"


### PR DESCRIPTION
Fixes #76 

- check that `xnat_config.site_name` starts with a letter and contains only letters, numbers, and underscores