### PR TITLE
Remove redundant `ansible_port` variable

### DIFF
--- a/playbooks/molecule/resources/monitoring/inventory/hosts.yml
+++ b/playbooks/molecule/resources/monitoring/inventory/hosts.yml
@@ -5,12 +5,10 @@ all:
     mclient:
       hostname: molecule.mclient.local
       ansible_ip: 192.168.56.2
-      ansible_port: 22
 
     mserv:
       hostname: molecule.mserv.local
       ansible_ip: 192.168.56.3
-      ansible_port: 22
 
   # Ansible groups. Groups allow configuration and variables to be shared between hosts
   # Variables in group_vars/all will be shared between all hosts

--- a/playbooks/molecule/resources/xnat/inventory/hosts.yml
+++ b/playbooks/molecule/resources/xnat/inventory/hosts.yml
@@ -17,7 +17,6 @@ all:
       hostname: "xnat.cserv.local"
       ansible_ip: "192.168.56.4"
 
-
   # Ansible groups. Groups allow configuration and variables to be shared between hosts
   # Variables in group_vars/all will be shared between all hosts
   children:

--- a/playbooks/molecule/resources/xnat/inventory/hosts.yml
+++ b/playbooks/molecule/resources/xnat/inventory/hosts.yml
@@ -6,17 +6,17 @@ all:
     xnat_db:
       hostname: "xnat.db.local"
       ansible_ip: "192.168.56.2"
-      ansible_port: 22
+
     # Host for your web server. Variables in host_vars/xnat_web will be available to this host
     xnat_web:
       hostname: "localhost" # necessary to allow redirects outside the Docker network and to avoid CORS issues inside the network
       ansible_ip: "192.168.56.3"
-      ansible_port: 22
+
     # Host for running the container service. Variables in host_vars/xnat_cserv will be available to this host
     xnat_cserv:
       hostname: "xnat.cserv.local"
       ansible_ip: "192.168.56.4"
-      ansible_port: 22
+
 
   # Ansible groups. Groups allow configuration and variables to be shared between hosts
   # Variables in group_vars/all will be shared between all hosts


### PR DESCRIPTION
Fixes #81 

- `ansible_port` is set to the default and there's no need to change it so we can safely remove it