### PR TITLE
Move db firewall config to molecule inventory

### DIFF
--- a/playbooks/group_vars/db.yml
+++ b/playbooks/group_vars/db.yml
@@ -40,10 +40,3 @@ postgresql_ssl_certificate:
 firewalld_rich_rules:
   - zone: "internal"
     rule: "family=ipv4 source address={{ web_server.subnet | default(web_server.ip + '/32') }} port protocol=tcp port={{ db_server.port }} accept"
-
-# mirsg.infrastructure.firewalld
-firewalld_internal_zone_sources:
-  - "{{ web_server.subnet | default(web_server.ip + '/32') }}"
-
-firewalld_internal_zone_open_services:
-  - "postgresql"

--- a/playbooks/molecule/resources/omero/inventory/group_vars/db.yml
+++ b/playbooks/molecule/resources/omero/inventory/group_vars/db.yml
@@ -1,0 +1,7 @@
+---
+# mirsg.infrastructure.firewalld
+firewalld_internal_zone_sources:
+  - "{{ web_server.subnet | default(web_server.ip + '/32') }}"
+
+firewalld_internal_zone_open_services:
+  - postgresql

--- a/playbooks/molecule/resources/xnat/inventory/group_vars/db.yml
+++ b/playbooks/molecule/resources/xnat/inventory/group_vars/db.yml
@@ -1,0 +1,7 @@
+---
+# mirsg.infrastructure.firewalld
+firewalld_internal_zone_sources:
+  - "{{ web_server.subnet | default(web_server.ip + '/32') }}"
+
+firewalld_internal_zone_open_services:
+  - postgresql


### PR DESCRIPTION
Changes:

In PR #53 I added `firewalld_internal_zone_sources` and `firewalld_internal_zone_open_services` to `playbooks/group_vars/db.yml`. This PR reverts that change since it prevents SSH from working on the `db` host on a new deployment.