### PR TITLE
Fix upgrade postgresql playbook

### DIFF
--- a/playbooks/upgrade_postgresql.yml
+++ b/playbooks/upgrade_postgresql.yml
@@ -1,6 +1,6 @@
 ---
 - name: Stop related web services
-  hosts: web
+  hosts: omero,xnat
   become: true
   gather_facts: true
   tasks:
@@ -25,7 +25,7 @@
     - role: mirsg.infrastructure.postgresql_upgrade
 
 - name: Restart related web services
-  hosts: web
+  hosts: omero,xnat
   become: true
   gather_facts: true
   tasks:

--- a/playbooks/upgrade_postgresql.yml
+++ b/playbooks/upgrade_postgresql.yml
@@ -13,6 +13,8 @@
   hosts: db
   become: true
   gather_facts: true
+  vars:
+    postgresql_generate_certs: false
   vars_prompt:
     - name: postgreql_upgrade_current_version
       prompt: What is the version of postgres to upgrade from?

--- a/playbooks/upgrade_postgresql.yml
+++ b/playbooks/upgrade_postgresql.yml
@@ -13,8 +13,6 @@
   hosts: db
   become: true
   gather_facts: true
-  vars:
-    postgresql_generate_certs: false
   vars_prompt:
     - name: postgreql_upgrade_current_version
       prompt: What is the version of postgres to upgrade from?

--- a/roles/postgresql/README.md
+++ b/roles/postgresql/README.md
@@ -5,12 +5,15 @@ This role will install and configure a PostgreSQL database on a server.
 This role is tested on the following operating systems:
 
 - CentOS 7
+- Rocky Linux 9
 
 ## Role Variables
 
-There are several **optional** variables for the PostgreSQL server. See the [defaults here](defaults/main.yml).
+There are several **optional** variables for the PostgreSQL server. See the
+[defaults here](defaults/main.yml).
 
-There are also several **required** variables you will need to set before using this role.
+There are also several **required** variables you will need to set before using
+this role.
 
 ### Variables required by both the server and client
 
@@ -34,10 +37,14 @@ There are also several **required** variables you will need to set before using 
 | `postgresql_connection.listen_address`              | IP address(es) the server should listen on                                                                   |
 | `postgresql_connection.subnet_mask`                 | Subnet mask to apply to `postgresql_connection.client_ip` for incoming connections                           |
 
-Note, if `postgresql_use_ssl` is set to `true`, you will also need to define a `postgresql_ssl_certificate` variable
-for generating the server certificate.
-See the [`mirsg.infrastructure.ssl_certificates` README](../ssl_certificates/README.md) for a description of how to
-define this variable.
+Note, if `postgresql_use_ssl` is set to `true`, you will also need to define a
+`postgresql_ssl_certificate` variable. for generating the server certificate.
+Generation of new certificates can be disabled by setting
+`postgresql_generate_certs` to `false` (defaults to `true`).
+
+See the [`mirsg.infrastructure.ssl_certificates`
+README](../ssl_certificates/README.md) for a description of how to define this
+variable.
 
 ### Required variables for the PostgreSQL client
 
@@ -45,11 +52,14 @@ define this variable.
 | ------------------------------------------------------------- | ----------------------------------------------------- |
 | `postgresql_client_configuration.server_certificate_filename` | Where to copy the server certificate to on the client |
 
-Note, if `postgresql_use_ssl` is set to `true`, you can use [`mirsg.infrastructure.ssl_certificates`](../ssl_certificates/README.md) to generate an SSL certificate.
+Note, if `postgresql_use_ssl` is set to `true`, you can use
+[`mirsg.infrastructure.ssl_certificates`](../ssl_certificates/README.md) to
+generate an SSL certificate.
 
 ## Example Playbook
 
-To use this role with a dual-server setup (a dartase `db` and a web server `web`) you must first:
+To use this role with a dual-server setup (a dartase `db` and a web server
+`web`) you must first:
 
 - stop any running PostgreSQL service
 - create a SSL certificate for the client if using SSL:

--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -5,6 +5,7 @@ postgresql_service_name: "postgresql-{{ postgresql_version }}"
 postgresql_package_name: "postgresql{{ postgresql_version | replace('.', '') }}"
 postgresql_bin_directory: "/usr/pgsql-{{ postgresql_version }}/bin"
 postgresql_data_directory: "/var/lib/pgsql/{{ postgresql_version }}/data"
+postgresql_generate_certs: true
 
 # mirsg.postgresql - download and install
 postgresql_install:

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -153,7 +153,7 @@
   changed_when: false
 
 - name: Setup SSL
-  when: postgresql_use_ssl
+  when: postgresql_use_ssl and postgresql_generate_certs
   notify: Restart postgresql
   block:
     - name: Generate postgresql server certificate

--- a/roles/postgresql_upgrade/README.md
+++ b/roles/postgresql_upgrade/README.md
@@ -30,12 +30,33 @@ collection](../../playbooks/upgrade_postgresql.yml). To use this role, add it to
 the list of roles in a play:
 
 ```yaml
+- name: Stop related web services
+  hosts: web
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Stop web service
+      ansible.builtin.service:
+        name: tomcat
+        state: stopped
+
 - name: Upgrade Postgresql from version 12 to 14
-  hosts: all
+  hosts: db
   vars:
     postgreql_upgrade_current_version: 12
     postgreql_upgrade_new_version: 14
     postgresql_upgrade_data_dir: "/var/lib/pgsql/{{ postgreql_upgrade_new_version }}/data"
+    postgresql_upgrade_scripts_dir: "/var/lib/pgsql/{{ postgreql_upgrade_current_version }}/upgrade"
   roles:
     - mirsg.postgresql_upgrade
+
+- name: Restart related web services
+  hosts: web
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Restart web service
+      ansible.builtin.service:
+        name: tomcat
+        state: restarted
 ```

--- a/roles/postgresql_upgrade/tasks/main.yml
+++ b/roles/postgresql_upgrade/tasks/main.yml
@@ -1,37 +1,37 @@
 ---
-# - name: >-
-#     Check if new postgres directory already exists
-#   ansible.builtin.stat:
-#     path: "{{ postgresql_upgrade_data_dir }}"
-#   register: postgresql_upgrade_new_data_dir
+- name: >-
+    Check if new postgres directory already exists
+  ansible.builtin.stat:
+    path: "{{ postgresql_upgrade_data_dir }}"
+  register: postgresql_upgrade_new_data_dir
 
-# - name: >-
-#     Fail if new postgres data directory already exists
-#   ansible.builtin.fail:
-#     msg: >
-#       Cannot upgrade because the new postgres directory
-#       {{ postgresql_upgrade_data_dir }} already exists; this suggests an
-#       upgrade has already been attempted
-#   when: postgresql_upgrade_new_data_dir.stat.exists and postgresql_upgrade_new_data_dir.stat.isdir
+- name: >-
+    Fail if new postgres data directory already exists
+  ansible.builtin.fail:
+    msg: >
+      Cannot upgrade because the new postgres directory
+      {{ postgresql_upgrade_data_dir }} already exists; this suggests an
+      upgrade has already been attempted
+  when: postgresql_upgrade_new_data_dir.stat.exists and postgresql_upgrade_new_data_dir.stat.isdir
 
-# - name: Back up PostgreSQL
-#   ansible.builtin.command: "{{ postgreql_upgrade_backup_script }}"
-#   become: true
-#   become_user: postgres
-#   changed_when: false
+- name: Back up PostgreSQL
+  ansible.builtin.command: "{{ postgreql_upgrade_backup_script }}"
+  become: true
+  become_user: postgres
+  changed_when: false
 
-# - name: Disable previous version of PostgreSQL - {{ postgreql_upgrade_current_version }}
-#   ansible.builtin.service:
-#     name: "postgresql-{{ postgreql_upgrade_current_version }}"
-#     state: stopped
-#     enabled: false
+- name: Disable previous version of PostgreSQL - {{ postgreql_upgrade_current_version }}
+  ansible.builtin.service:
+    name: "postgresql-{{ postgreql_upgrade_current_version }}"
+    state: stopped
+    enabled: false
 
-# - name: Install new version of PostgreSQL - {{ postgreql_upgrade_new_version }}
-#   ansible.builtin.include_role:
-#     name: mirsg.infrastructure.postgresql
-#   vars:
-#     postgresql_version: "{{ postgreql_upgrade_new_version }}" # noqa var-naming[no-role-prefix]
-#     postgresql_create_database: false
+- name: Install new version of PostgreSQL - {{ postgreql_upgrade_new_version }}
+  ansible.builtin.include_role:
+    name: mirsg.infrastructure.postgresql
+  vars:
+    postgresql_version: "{{ postgreql_upgrade_new_version }}" # noqa var-naming[no-role-prefix]
+    postgresql_create_database: false
 
 - name: Ensure new postgres is not running
   ansible.builtin.service:

--- a/roles/postgresql_upgrade/tasks/main.yml
+++ b/roles/postgresql_upgrade/tasks/main.yml
@@ -32,6 +32,7 @@
   vars:
     postgresql_version: "{{ postgreql_upgrade_new_version }}" # noqa var-naming[no-role-prefix]
     postgresql_create_database: false
+    postgresql_generate_certs: false
 
 - name: Ensure new postgres is not running
   ansible.builtin.service:

--- a/roles/postgresql_upgrade/tasks/main.yml
+++ b/roles/postgresql_upgrade/tasks/main.yml
@@ -1,37 +1,37 @@
 ---
-- name: >-
-    Check if new postgres directory already exists
-  ansible.builtin.stat:
-    path: "{{ postgresql_upgrade_data_dir }}"
-  register: postgresql_upgrade_new_data_dir
+# - name: >-
+#     Check if new postgres directory already exists
+#   ansible.builtin.stat:
+#     path: "{{ postgresql_upgrade_data_dir }}"
+#   register: postgresql_upgrade_new_data_dir
 
-- name: >-
-    Fail if new postgres data directory already exists
-  ansible.builtin.fail:
-    msg: >
-      Cannot upgrade because the new postgres directory
-      {{ postgresql_upgrade_data_dir }} already exists; this suggests an
-      upgrade has already been attempted
-  when: postgresql_upgrade_new_data_dir.stat.exists and postgresql_upgrade_new_data_dir.stat.isdir
+# - name: >-
+#     Fail if new postgres data directory already exists
+#   ansible.builtin.fail:
+#     msg: >
+#       Cannot upgrade because the new postgres directory
+#       {{ postgresql_upgrade_data_dir }} already exists; this suggests an
+#       upgrade has already been attempted
+#   when: postgresql_upgrade_new_data_dir.stat.exists and postgresql_upgrade_new_data_dir.stat.isdir
 
-- name: Back up PostgreSQL
-  ansible.builtin.command: "{{ postgreql_upgrade_backup_script }}"
-  become: true
-  become_user: postgres
-  changed_when: false
+# - name: Back up PostgreSQL
+#   ansible.builtin.command: "{{ postgreql_upgrade_backup_script }}"
+#   become: true
+#   become_user: postgres
+#   changed_when: false
 
-- name: Disable previous version of PostgreSQL - {{ postgreql_upgrade_current_version }}
-  ansible.builtin.service:
-    name: "postgresql-{{ postgreql_upgrade_current_version }}"
-    state: stopped
-    enabled: false
+# - name: Disable previous version of PostgreSQL - {{ postgreql_upgrade_current_version }}
+#   ansible.builtin.service:
+#     name: "postgresql-{{ postgreql_upgrade_current_version }}"
+#     state: stopped
+#     enabled: false
 
-- name: Install new version of PostgreSQL - {{ postgreql_upgrade_new_version }}
-  ansible.builtin.include_role:
-    name: mirsg.infrastructure.postgresql
-  vars:
-    postgresql_version: "{{ postgreql_upgrade_new_version }}" # noqa var-naming[no-role-prefix]
-    postgresql_create_database: false
+# - name: Install new version of PostgreSQL - {{ postgreql_upgrade_new_version }}
+#   ansible.builtin.include_role:
+#     name: mirsg.infrastructure.postgresql
+#   vars:
+#     postgresql_version: "{{ postgreql_upgrade_new_version }}" # noqa var-naming[no-role-prefix]
+#     postgresql_create_database: false
 
 - name: Ensure new postgres is not running
   ansible.builtin.service:


### PR DESCRIPTION
Changes:

- Correct `hosts` for `upgrade_postgresql.yml` playbook in line with changes to playbook level group names
- Add a flag to set whether the `mirsg.infrastructure.postgresql` role should generate a new server cert
- Improve the example for how to use the `mirsg.infrastructure.postgresql_upgrade` role in a playbook