### PR TITLE
Install the correct versions of `docker-ce` and `docker-ce-cli`

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -34,7 +34,7 @@
   ansible.builtin.yum:
     name: "{{ item }}"
     state: installed
-  allow_downgrade: true
+    allow_downgrade: true
   loop:
     # https://groups.google.com/g/xnat_discussion/c/yyPBkN4kayE/m/LUe5GQH5AAAJ
     - docker-ce-24.0.9

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -34,6 +34,7 @@
   ansible.builtin.yum:
     name: "{{ item }}"
     state: installed
+  allow_downgrade: true
   loop:
     # https://groups.google.com/g/xnat_discussion/c/yyPBkN4kayE/m/LUe5GQH5AAAJ
     - docker-ce-24.0.9

--- a/roles/provision/tasks/main.yml
+++ b/roles/provision/tasks/main.yml
@@ -11,6 +11,10 @@
   ansible.builtin.yum:
     name: "*"
     state: latest
+  exclude:
+    # https://groups.google.com/g/xnat_discussion/c/yyPBkN4kayE/m/LUe5GQH5AAAJ
+    - docker-ce
+    - docker-ce-cli
   tags:
     - molecule-idempotence-notest
 

--- a/roles/provision/tasks/main.yml
+++ b/roles/provision/tasks/main.yml
@@ -11,10 +11,10 @@
   ansible.builtin.yum:
     name: "*"
     state: latest
-  exclude:
-    # https://groups.google.com/g/xnat_discussion/c/yyPBkN4kayE/m/LUe5GQH5AAAJ
-    - docker-ce
-    - docker-ce-cli
+    exclude:
+      # https://groups.google.com/g/xnat_discussion/c/yyPBkN4kayE/m/LUe5GQH5AAAJ
+      - docker-ce
+      - docker-ce-cli
   tags:
     - molecule-idempotence-notest
 


### PR DESCRIPTION
Fixes #105 

- don't upgrade `docker-ce` and `docker-ce-cli` in `mirsg.infrastructure.provision`
- allow `docker-ce` and `docker-ce-cli` version to be downgraded in `mirsg.infrastructure.docker`
