### PR TITLE
Playbook to restart xnat and omero

### DIFF
--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -88,3 +88,14 @@ jobs:
 This uses the
 [`.github/workflows/molecule.yml` reusable workflow](.github/workflows/molecule.yml)
 to run molecule on the relevant role.
+
+## Playbooks
+
+| Playbook | Description |
+|----------|-------------|
+| [install_monitoring.yml](./install_monitoring.yml) | Playbook for installing Dockerised deployment of Prometheus on the monitoring server and `node_exporter` on each of the client servers to be monitored. |
+| [install_omero.yml](./install_omero.yml) | Playbook for installing OMERO.server and OMERO.web along with Postgresql in a separate host. |
+| [install_xnat.yml](./install_xnat.yml) | Playbook for installing XNAT along with Postgresql in a separate host. |
+| [restart_xnat_or_omero.yml](./restart_xnat_or_omero.yml) | Playbook for restarting XNAT or OMERO (as well as the associated Postgresql service). To be used in the event of a system outage. To run a restart for OMERO make sure to set the `services_to_restart` variable when calling the playbook to `['omero-server', 'omero-web']`. |
+| [setup_user_accounts.yml](./setup_user_accounts.yml) | Playbook for adding MIRSG administrator accounts to the application and database hosts. |
+| [upgrade_postgresql.yml](./upgrade_postgresql.yml) | Playbook for running an upgrade of Postgresql. |

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -91,11 +91,11 @@ to run molecule on the relevant role.
 
 ## Playbooks
 
-| Playbook | Description |
-|----------|-------------|
-| [install_monitoring.yml](./install_monitoring.yml) | Playbook for installing Dockerised deployment of Prometheus on the monitoring server and `node_exporter` on each of the client servers to be monitored. |
-| [install_omero.yml](./install_omero.yml) | Playbook for installing OMERO.server and OMERO.web along with Postgresql in a separate host. |
-| [install_xnat.yml](./install_xnat.yml) | Playbook for installing XNAT along with Postgresql in a separate host. |
+| Playbook                                                 | Description                                                                                                                                                                                                                                                                    |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [install_monitoring.yml](./install_monitoring.yml)       | Playbook for installing Dockerised deployment of Prometheus on the monitoring server and `node_exporter` on each of the client servers to be monitored.                                                                                                                        |
+| [install_omero.yml](./install_omero.yml)                 | Playbook for installing OMERO.server and OMERO.web along with Postgresql in a separate host.                                                                                                                                                                                   |
+| [install_xnat.yml](./install_xnat.yml)                   | Playbook for installing XNAT along with Postgresql in a separate host.                                                                                                                                                                                                         |
 | [restart_xnat_or_omero.yml](./restart_xnat_or_omero.yml) | Playbook for restarting XNAT or OMERO (as well as the associated Postgresql service). To be used in the event of a system outage. To run a restart for OMERO make sure to set the `services_to_restart` variable when calling the playbook to `['omero-server', 'omero-web']`. |
-| [setup_user_accounts.yml](./setup_user_accounts.yml) | Playbook for adding MIRSG administrator accounts to the application and database hosts. |
-| [upgrade_postgresql.yml](./upgrade_postgresql.yml) | Playbook for running an upgrade of Postgresql. |
+| [setup_user_accounts.yml](./setup_user_accounts.yml)     | Playbook for adding MIRSG administrator accounts to the application and database hosts.                                                                                                                                                                                        |
+| [upgrade_postgresql.yml](./upgrade_postgresql.yml)       | Playbook for running an upgrade of Postgresql.                                                                                                                                                                                                                                 |

--- a/playbooks/restart_xnat_or_omero.yml
+++ b/playbooks/restart_xnat_or_omero.yml
@@ -18,7 +18,9 @@
             state: started
           when: "'is not a mountpoint' in check_mountpoint.stdout"
 
-        - name: Check that storage has been mounted correctly if it was previously not mounted
+        - name:
+            Check that storage has been mounted correctly if it was previously
+            not mounted
           ansible.builtin.command: mountpoint {{ external_storage_drive }}
           when: "'is not a mountpoint' in check_mountpoint.stdout"
           register: check_mountpoint_again
@@ -44,7 +46,9 @@
         state: restarted
       loop: "{{ services_to_restart | default(['tomcat']) }}"
 
-    - name: "Waiting for application to start - this could take several minutes: {{ web_server.url }}"
+    - name:
+        "Waiting for application to start - this could take several minutes: {{
+        web_server.url }}"
       ansible.builtin.uri:
         url: "{{ web_server.url }}"
         method: GET

--- a/playbooks/restart_xnat_or_omero.yml
+++ b/playbooks/restart_xnat_or_omero.yml
@@ -34,8 +34,8 @@
         name: "postgresql-{{ postgresql_version }}"
         state: restarted
 
-- name: Ensure the web server is available
-  hosts: web
+- name: Ensure the application services are available
+  hosts: omero,xnat
   become: true
   tasks:
     - name: Ensure services are running

--- a/playbooks/restart_xnat_or_omero.yml
+++ b/playbooks/restart_xnat_or_omero.yml
@@ -33,7 +33,7 @@
   tasks:
     - name: "Ensure PostgreSQL is running: postgresql-{{ postgresql_version }}"
       ansible.builtin.service:
-        name: "postgresql-{{ postgresql_version }}"
+        name: postgresql-"{{ postgresql_version }}"
         state: restarted
 
 - name: Ensure the application services are available

--- a/playbooks/restart_xnat_or_omero.yml
+++ b/playbooks/restart_xnat_or_omero.yml
@@ -33,7 +33,7 @@
   tasks:
     - name: "Ensure PostgreSQL is running: postgresql-{{ postgresql_version }}"
       ansible.builtin.service:
-        name: "postgresql-{{ postgresql_version }}"
+        name: "postgresql-{{ postgresql_version }}" # yamllint disable-line rule:quoted-strings
         state: restarted
 
 - name: Ensure the application services are available

--- a/playbooks/restart_xnat_or_omero.yml
+++ b/playbooks/restart_xnat_or_omero.yml
@@ -33,7 +33,7 @@
   tasks:
     - name: "Ensure PostgreSQL is running: postgresql-{{ postgresql_version }}"
       ansible.builtin.service:
-        name: postgresql-"{{ postgresql_version }}"
+        name: "postgresql-{{ postgresql_version }}"
         state: restarted
 
 - name: Ensure the application services are available

--- a/playbooks/restart_xnat_or_omero.yml
+++ b/playbooks/restart_xnat_or_omero.yml
@@ -1,0 +1,55 @@
+---
+- name: Ensure storage is mounted
+  hosts: all
+  become: true
+  tasks:
+    - name: Ensure storage is mounted
+      when: external_storage_drive is defined
+      block:
+        - name: "Check if storage is mounted: {{ external_storage_drive }}"
+          ansible.builtin.command: mountpoint {{ external_storage_drive }}
+          register: check_mountpoint
+          failed_when: false
+          changed_when: false
+
+        - name: Start autofs if storage is not mounted
+          ansible.builtin.service:
+            name: autofs
+            state: started
+          when: "'is not a mountpoint' in check_mountpoint.stdout"
+
+        - name: Check that storage has been mounted correctly if it was previously not mounted
+          ansible.builtin.command: mountpoint {{ external_storage_drive }}
+          when: "'is not a mountpoint' in check_mountpoint.stdout"
+          register: check_mountpoint_again
+          failed_when: "'is not a mountpoint' in check_mountpoint_again.stdout"
+          changed_when: "'is a mountpoint' in check_mountpoint_again.stdout"
+
+- name: Ensure the database is available
+  hosts: db
+  become: true
+  tasks:
+    - name: "Ensure PostgreSQL is running: postgresql-{{ postgresql_version }}"
+      ansible.builtin.service:
+        name: "postgresql-{{ postgresql_version }}"
+        state: restarted
+
+- name: Ensure the web server is available
+  hosts: web
+  become: true
+  tasks:
+    - name: Ensure services are running
+      ansible.builtin.service:
+        name: "{{ item }}"
+        state: restarted
+      loop: "{{ services_to_restart | default(['tomcat']) }}"
+
+    - name: "Waiting for application to start - this could take several minutes: {{ web_server.url }}"
+      ansible.builtin.uri:
+        url: "{{ web_server.url }}"
+        method: GET
+        validate_certs: "{{ ssl.validate_certs }}"
+      register: _result
+      until: _result.status == 200
+      retries: 10
+      delay: 30


### PR DESCRIPTION
Add a playbook to restart database, XNAT or OMERO after an outage.

Tested on XNAT and OMERO instances deployed on `mirsg-dev.cs.ucl.ac.uk`.

Closes #118 