### PR TITLE
Change nginx template to accommodate long aws url

### DIFF
--- a/roles/nginx/templates/nginx_reverse_proxy.j2
+++ b/roles/nginx/templates/nginx_reverse_proxy.j2
@@ -24,6 +24,7 @@ stream {
 {% endif %}
 
 http {
+    server_names_hash_bucket_size  128;
     sendfile            off;
 #    sendfile            on; can cause a problem in VirtualBox
     tcp_nopush          on;


### PR DESCRIPTION
Getting the following nginx error when running `./install_xnat.sh` in [xnat-aws repo](https://github.com/UCL-MIRSG/xnat-aws/blob/3be5e69335fa02b4a86b7d5d249cc9c849ec7249/README.md#L71-L72)
```
nginx: [emerg] could not build server_names_hash, you should increase server_names_hash_bucket_size: 64
nginx: configuration file /etc/nginx/nginx.conf test failed
nginx.service: Control process exited, code=exited, status=1/FAILURE
```

The url is too long so don't know if it's possible to make it shorter
`xnat_web_url = "http://ec2-18-171-61-42.eu-west-2.compute.amazonaws.com"`
OR
adding `server_names_hash_bucket_size  128;` to the http block within `/etc/nginx/nginx.conf` which worked when manually changing it on the server
