### PR TITLE
Use CentOS 7 vault for the YUM repos

### DIFF
--- a/roles/provision/README.md
+++ b/roles/provision/README.md
@@ -1,25 +1,33 @@
-# Ansible Role: mirsg.provision
+# Ansible Role: mirsg.infrastructure.provision
 
 This role sets up for a specific distribution for CentOS (mirrorlist and locale)
 or Rocky8 (disable postgres), upgrades all packages and ensures epel is
 installed.
 
-## Requirements
-
-If you would like to run Ansible Molecule to test this role, the requirements
-are in
-[`requirements.txt`](https://github.com/UCL-MIRSG/ansible-role-install-python/blob/main/requirements.txt).
-
 ## Role Variables
 
-`postgresql_rpm_gpg_key_pgdg_x86_64`: the postgresql key for Intel chips.
-`postgresql_rpm_gpg_key_pgdg_x86_64`: the postgresql key for ARM chips. These
-are not needed for CentOS 7.
+The following variables can be set for provisioning CentOS 7:
 
-`server_locale`: the sets the user's language, region, etc. This is set to
-"en_GB.UTF-8"
+| Name                                    | Description                                                                                                       |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `provision_yum_repo_base_baseurl`       | baseurl for YUM base repo. Defaults to `http://vault.centos.org/centos/$releasever/os/$basearch/`                 |
+| `provision_yum_repo_updates_baseurl`    | baseurl for YUM updates repo updates. Defaults to `http://vault.centos.org/centos/$releasever/updates/$basearch/` |
+| `provision_yum_repo_extras_baseurl`     | baseurl for YUM extra repo extras. Defaults to `http://vault.centos.org/centos/$releasever/extras/$basearch/`     |
+| `provision_yum_repo_centosplus_baseurl` | baseurl for YUM centosplus repo. Defaults to `http://vault.centos.org/centos/$releasever/centosplus/$basearch/`   |
 
-`external_storage_drive`: path to mounted storage. By default this is undefined.
+The following variables can be set for provisioning Rocky 8+:
+
+| Name                                  | Description                         |
+| ------------------------------------- | ----------------------------------- |
+| `postgresql_rpm_gpg_key_pgdg_x86_64`  | the postgresql key for Intel chips. |
+| `postgresql_rpm_gpg_key_pgdg_aarch64` | the postgresql key for ARM chips    |
+
+The following variables can be set for either CentOS 7 or Rocky 8+:
+
+| Name                     | Description                                                          |
+| ------------------------ | -------------------------------------------------------------------- |
+| `server_locale`          | sets the user's language, region, etc. This is set to "en_GB.UTF-8"  |
+| `external_storage_drive` | path to mounted storage (if using it). By default this is undefined. |
 
 ## Dependencies
 
@@ -34,15 +42,5 @@ it to the list of roles in a play:
 - name: Provision
   hosts: all
   roles:
-    - mirsg.provision
+    - mirsg.infrastructure.provision
 ```
-
-## License
-
-[BSD 3-Clause License](https://github.com/UCL-MIRSG/ansible-role-install-python/blob/main/LICENSE).
-
-## Author Information
-
-This role was created by the
-[Medical Imaging Research Software Group](https://www.ucl.ac.uk/advanced-research-computing/expertise/research-software-development/medical-imaging-research-software-group)
-at [UCL](https://www.ucl.ac.uk/).

--- a/roles/provision/defaults/main.yml
+++ b/roles/provision/defaults/main.yml
@@ -1,4 +1,9 @@
 ---
+provision_yum_repo_base_baseurl: http://vault.centos.org/centos/$releasever/os/$basearch/
+provision_yum_repo_updates_baseurl: http://vault.centos.org/centos/$releasever/updates/$basearch/
+provision_yum_repo_extras_baseurl: http://vault.centos.org/centos/$releasever/extras/$basearch/
+provision_yum_repo_centosplus_baseurl: http://vault.centos.org/centos/$releasever/centosplus/$basearch/
+
 # not needed for CentOS 7
 postgresql_rpm_gpg_key_pgdg_x86_64: >-
   https://apt.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL

--- a/roles/provision/tasks/CentOS.yml
+++ b/roles/provision/tasks/CentOS.yml
@@ -1,21 +1,46 @@
 ---
-- name: Ensure base mirrorlist is in repository file (CentOS)
-  community.general.ini_file:
-    path: /etc/yum.repos.d/CentOS-Base.repo
-    section: base
-    option: mirrorlist
-    value: http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os
-    backup: true
-    mode: "0644"
+- name: Ensure os baseurl is present in repository file
+  ansible.builtin.yum_repository:
+    name: base
+    description: CentOS-$releasever - Base
+    file: CentOS-Base
+    baseurl: "{{ provision_yum_repo_base_baseurl }}"
+    gpgcheck: true
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+    enabled: true
+    state: present
 
-- name: Ensure updates mirrorlist is in repository file (CentOS)
-  community.general.ini_file:
-    path: /etc/yum.repos.d/CentOS-Base.repo
-    section: updates
-    option: mirrorlist
-    value: http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates
-    backup: true
-    mode: "0644"
+- name: Ensure updates baseurl is present in repository file
+  ansible.builtin.yum_repository:
+    name: updates
+    description: CentOS-$releasever - Updates
+    file: CentOS-Base
+    baseurl: "{{ provision_yum_repo_updates_baseurl }}"
+    gpgcheck: true
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+    enabled: true
+    state: present
+
+- name: Ensure extras baseurl is present in repository file
+  ansible.builtin.yum_repository:
+    name: extras
+    description: CentOS-$releasever - Extras
+    file: CentOS-Base
+    baseurl: "{{ provision_yum_repo_extras_baseurl }}"
+    gpgcheck: true
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+    state: present
+
+- name: Ensure centosplus baseurl is present in repository file
+  ansible.builtin.yum_repository:
+    name: centosplus
+    description: CentOS-$releasever - Plus
+    file: CentOS-Base
+    baseurl: "{{ provision_yum_repo_centosplus_baseurl }}"
+    gpgcheck: true
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+    enabled: false
+    state: present
 
 - name: Check if locale already set
   ansible.builtin.shell: |


### PR DESCRIPTION
Fixes #123 

- remove previous mirrorlist from YUM repo configs
- add default baseurls that point to the CentOS 7 vault
- add variables to change the baseurl
- update README with new variables
- update README to reflect the role is now part of a collection rather than a standalone role