### PR TITLE
Update YUM repo baseurls on CentOS 7 in prepare step for all molecule tests

### DIFF
--- a/playbooks/molecule/resources/monitoring/prepare.yml
+++ b/playbooks/molecule/resources/monitoring/prepare.yml
@@ -3,6 +3,14 @@
   hosts: all
   gather_facts: true
   tasks:
+    - name: Update YUM repo baseurls
+      ansible.builtin.include_role:
+        name: mirsg.infrastructure.provision
+        tasks_from: CentOS.yml
+      when:
+        ansible_facts['os_family'] == "RedHat" and
+        ansible_facts['distribution_major_version'] is version('7')
+
     - name: Install sudo
       ansible.builtin.package:
         name: sudo

--- a/playbooks/molecule/resources/shared/prepare.yml
+++ b/playbooks/molecule/resources/shared/prepare.yml
@@ -1,8 +1,16 @@
 ---
-- name: Prepare - install sudo
+- name: Prepare - set baseurls for YUM repos and install sudo
   hosts: all
   gather_facts: true
   tasks:
+    - name: Update YUM repo baseurls
+      ansible.builtin.include_role:
+        name: mirsg.infrastructure.provision
+        tasks_from: CentOS.yml
+      when:
+        ansible_facts['os_family'] == "RedHat" and
+        ansible_facts['distribution_major_version'] is version('7')
+
     - name: Install sudo
       ansible.builtin.package:
         name: sudo

--- a/roles/docker/molecule/resources/prepare.yml
+++ b/roles/docker/molecule/resources/prepare.yml
@@ -3,9 +3,17 @@
   hosts: all
   gather_facts: true
   pre_tasks:
+    - name: Update YUM repo baseurls
+      ansible.builtin.include_role:
+        name: mirsg.infrastructure.provision
+        tasks_from: CentOS.yml
+      when:
+        ansible_facts['os_family'] == "RedHat" and
+        ansible_facts['distribution_major_version'] is version('7')
     - name: Install sudo
       ansible.builtin.package:
         name: sudo
         state: present
+
   roles:
     - role: mirsg.infrastructure.install_python

--- a/roles/firewalld/molecule/resources/prepare.yml
+++ b/roles/firewalld/molecule/resources/prepare.yml
@@ -3,6 +3,14 @@
   hosts: all
   gather_facts: true
   tasks:
+    - name: Update YUM repo baseurls
+      ansible.builtin.include_role:
+        name: mirsg.infrastructure.provision
+        tasks_from: CentOS.yml
+      when:
+        ansible_facts['os_family'] == "RedHat" and
+        ansible_facts['distribution_major_version'] is version('7')
+
     - name: Install sudo
       ansible.builtin.package:
         name: sudo

--- a/roles/install_java/molecule/resources/prepare.yml
+++ b/roles/install_java/molecule/resources/prepare.yml
@@ -3,6 +3,14 @@
   hosts: all
   gather_facts: true
   tasks:
+    - name: Update YUM repo baseurls
+      ansible.builtin.include_role:
+        name: mirsg.infrastructure.provision
+        tasks_from: CentOS.yml
+      when:
+        ansible_facts['os_family'] == "RedHat" and
+        ansible_facts['distribution_major_version'] is version('7')
+
     - name: Install sudo
       ansible.builtin.package:
         name: sudo

--- a/roles/install_python/molecule/resources/prepare.yml
+++ b/roles/install_python/molecule/resources/prepare.yml
@@ -3,6 +3,14 @@
   hosts: all
   gather_facts: true
   tasks:
+  pre_tasks:
+    - name: Update YUM repo baseurls
+      ansible.builtin.include_role:
+        name: mirsg.infrastructure.provision
+        tasks_from: CentOS.yml
+      when:
+        ansible_facts['os_family'] == "RedHat" and
+        ansible_facts['distribution_major_version'] is version('7')
     - name: Install sudo
       ansible.builtin.package:
         name: sudo

--- a/roles/nginx/molecule/resources/prepare.yml
+++ b/roles/nginx/molecule/resources/prepare.yml
@@ -3,6 +3,13 @@
   hosts: all
   gather_facts: true
   tasks:
+    - name: Update YUM repo baseurls
+      ansible.builtin.include_role:
+        name: mirsg.infrastructure.provision
+        tasks_from: CentOS.yml
+      when:
+        ansible_facts['os_family'] == "RedHat" and
+        ansible_facts['distribution_major_version'] is version('7')
     - name: Install sudo
       ansible.builtin.package:
         name: sudo

--- a/roles/postgresql/molecule/resources/prepare.yml
+++ b/roles/postgresql/molecule/resources/prepare.yml
@@ -3,6 +3,14 @@
   hosts: all
   gather_facts: true
   pre_tasks:
+    - name: Update YUM repo baseurls
+      ansible.builtin.include_role:
+        name: mirsg.infrastructure.provision
+        tasks_from: CentOS.yml
+      when:
+        ansible_facts['os_family'] == "RedHat" and
+        ansible_facts['distribution_major_version'] is version('7')
+
     - name: Install sudo
       ansible.builtin.package:
         name: sudo

--- a/roles/postgresql_upgrade/molecule/resources/prepare.yml
+++ b/roles/postgresql_upgrade/molecule/resources/prepare.yml
@@ -3,6 +3,14 @@
   hosts: all
   gather_facts: true
   pre_tasks:
+    - name: Update YUM repo baseurls
+      ansible.builtin.include_role:
+        name: mirsg.infrastructure.provision
+        tasks_from: CentOS.yml
+      when:
+        ansible_facts['os_family'] == "RedHat" and
+        ansible_facts['distribution_major_version'] is version('7')
+
     - name: Install sudo
       ansible.builtin.package:
         name: sudo

--- a/roles/provision_accounts/molecule/resources/prepare.yml
+++ b/roles/provision_accounts/molecule/resources/prepare.yml
@@ -3,6 +3,14 @@
   hosts: all
   gather_facts: true
   tasks:
+    - name: Update YUM repo baseurls
+      ansible.builtin.include_role:
+        name: mirsg.infrastructure.provision
+        tasks_from: CentOS.yml
+      when:
+        ansible_facts['os_family'] == "RedHat" and
+        ansible_facts['distribution_major_version'] is version('7')
+
     - name: Install sudo
       ansible.builtin.package:
         name: sudo

--- a/roles/tomcat/molecule/resources/prepare.yml
+++ b/roles/tomcat/molecule/resources/prepare.yml
@@ -3,6 +3,14 @@
   hosts: all
   gather_facts: true
   pre_tasks:
+    - name: Update YUM repo baseurls
+      ansible.builtin.include_role:
+        name: mirsg.infrastructure.provision
+        tasks_from: CentOS.yml
+      when:
+        ansible_facts['os_family'] == "RedHat" and
+        ansible_facts['distribution_major_version'] is version('7')
+
     - name: Install sudo
       ansible.builtin.package:
         name: sudo


### PR DESCRIPTION
Follow up to #124 

- molecule tests currently [fail](https://github.com/UCL-MIRSG/ansible-collection-infra/actions/runs/9939463787/job/27454089186#step:2:2460) because the default mirrorlist no longer exists since CentOS 7 is end-of-life
- set correct baseurl for YUM repos when running molecule tests on CentOS 7