### PR TITLE
Remove stream directive, define default_dicom_listen_port directly

### DIFF
--- a/playbooks/group_vars/xnat.yml
+++ b/playbooks/group_vars/xnat.yml
@@ -80,18 +80,18 @@ firewalld_work_zone_open_services:
   - https
 
 firewalld_internal_zone_ports:
-  - "{{ nginx_default_dicom_listen_port }}"
+  - "{{ nginx_upstream_listen_port }}"
 
 firewalld_work_zone_ports:
-  - "{{ nginx_default_dicom_listen_port }}"
+  - "{{ nginx_upstream_listen_port }}"
 
 firewalld_public_zone_ports:
-  - "{{ nginx_default_dicom_listen_port }}"
+  - "{{ nginx_upstream_listen_port }}"
 
 # mirsg.infrastructure.nginx
 nginx_use_ssl: "{{ ssl.use_ssl }}"
 nginx_server_name: "{{ web_server.host }}"
-nginx_default_dicom_listen_port: 8104
+nginx_upstream_listen_port: 8104
 nginx_proxy_port: 8080 # tomcat
 nginx_root: /usr/share/tomcat/webapps/ROOT
 nginx_app_access_log: "{{ nginx_log_folder }}/xnat.access.log"

--- a/playbooks/group_vars/xnat.yml
+++ b/playbooks/group_vars/xnat.yml
@@ -80,19 +80,18 @@ firewalld_work_zone_open_services:
   - https
 
 firewalld_internal_zone_ports:
-  - "{{ nginx_upstream_listen_port }}"
+  - "{{ default_dicom_listen_port }}"
 
 firewalld_work_zone_ports:
-  - "{{ nginx_upstream_listen_port }}"
+  - "{{ default_dicom_listen_port }}"
 
 firewalld_public_zone_ports:
-  - "{{ nginx_upstream_listen_port }}"
+  - "{{ default_dicom_listen_port }}"
 
 # mirsg.infrastructure.nginx
 nginx_use_ssl: "{{ ssl.use_ssl }}"
 nginx_server_name: "{{ web_server.host }}"
-nginx_upstream_port: 8104
-nginx_upstream_listen_port: 8104
+default_dicom_listen_port: 8104
 nginx_proxy_port: 8080 # tomcat
 nginx_root: /usr/share/tomcat/webapps/ROOT
 nginx_app_access_log: "{{ nginx_log_folder }}/xnat.access.log"

--- a/playbooks/group_vars/xnat.yml
+++ b/playbooks/group_vars/xnat.yml
@@ -80,18 +80,18 @@ firewalld_work_zone_open_services:
   - https
 
 firewalld_internal_zone_ports:
-  - "{{ default_dicom_listen_port }}"
+  - "{{ nginx_default_dicom_listen_port }}"
 
 firewalld_work_zone_ports:
-  - "{{ default_dicom_listen_port }}"
+  - "{{ nginx_default_dicom_listen_port }}"
 
 firewalld_public_zone_ports:
-  - "{{ default_dicom_listen_port }}"
+  - "{{ nginx_default_dicom_listen_port }}"
 
 # mirsg.infrastructure.nginx
 nginx_use_ssl: "{{ ssl.use_ssl }}"
 nginx_server_name: "{{ web_server.host }}"
-default_dicom_listen_port: 8104
+nginx_default_dicom_listen_port: 8104
 nginx_proxy_port: 8080 # tomcat
 nginx_root: /usr/share/tomcat/webapps/ROOT
 nginx_app_access_log: "{{ nginx_log_folder }}/xnat.access.log"

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -5,13 +5,13 @@
   block:
     - name:
         Configure SELinux to allow nginx to listen on port {{
-        nginx_default_dicom_listen_port }}
+        nginx_upstream_listen_port }}
       community.general.seport:
-        ports: "{{ nginx_default_dicom_listen_port }}"
+        ports: "{{ nginx_upstream_listen_port }}"
         proto: tcp
         setype: http_port_t
         state: present
-      when: nginx_default_dicom_listen_port is defined
+      when: nginx_upstream_listen_port is defined
 
     - name:
         Configure SELinux to allow httpd to act as relay and keep it persistent

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -5,13 +5,13 @@
   block:
     - name:
         Configure SELinux to allow nginx to listen on port {{
-        nginx_upstream_listen_port }}
+        default_dicom_listen_port }}
       community.general.seport:
-        ports: "{{ nginx_upstream_listen_port }}"
+        ports: "{{ default_dicom_listen_port }}"
         proto: tcp
         setype: http_port_t
         state: present
-      when: nginx_upstream_listen_port is defined
+      when: default_dicom_listen_port is defined
 
     - name:
         Configure SELinux to allow httpd to act as relay and keep it persistent

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -5,13 +5,13 @@
   block:
     - name:
         Configure SELinux to allow nginx to listen on port {{
-        default_dicom_listen_port }}
+        nginx_default_dicom_listen_port }}
       community.general.seport:
-        ports: "{{ default_dicom_listen_port }}"
+        ports: "{{ nginx_default_dicom_listen_port }}"
         proto: tcp
         setype: http_port_t
         state: present
-      when: default_dicom_listen_port is defined
+      when: nginx_default_dicom_listen_port is defined
 
     - name:
         Configure SELinux to allow httpd to act as relay and keep it persistent

--- a/roles/nginx/templates/nginx_reverse_proxy.j2
+++ b/roles/nginx/templates/nginx_reverse_proxy.j2
@@ -10,19 +10,6 @@ events {
     worker_connections  1024;
 }
 
-{% if nginx_upstream_port is defined and nginx_upstream_listen_port is defined %}
-stream {
-    upstream backend {
-        server localhost:{{ nginx_upstream_port }};
-    }
-
-    server {
-        listen {{ nginx_upstream_listen_port }};
-        proxy_pass backend;
-    }
-}
-{% endif %}
-
 http {
     sendfile            off;
 #    sendfile            on; can cause a problem in VirtualBox


### PR DESCRIPTION
Closes #119 

This is done by removing the `stream` directive from the `nginx` configuration so that the define port is only listened to by `tomcat`.