### PR TITLE
Update container service

### DIFF
--- a/playbooks/install_xnat.yml
+++ b/playbooks/install_xnat.yml
@@ -6,6 +6,9 @@
 
   roles:
     - role: mirsg.infrastructure.provision
+      vars:
+        provision_mount_points:
+          - "{{ external_storage_drive }}"
     - role: mirsg.infrastructure.install_python
     - role: mirsg.infrastructure.install_java
     - role: mirsg.infrastructure.tomcat
@@ -22,6 +25,9 @@
 
   roles:
     - role: mirsg.infrastructure.provision
+      vars:
+        provision_mount_points:
+          - "{{ external_storage_drive }}"
     - role: mirsg.infrastructure.install_python
     - role: mirsg.infrastructure.postgresql
     - role: mirsg.infrastructure.firewalld
@@ -42,6 +48,9 @@
 
   roles:
     - role: mirsg.infrastructure.provision
+      vars:
+        provision_mount_points:
+          "{{ container_service_mounts | default([ external_storage_drive ]) }} "
     - role: mirsg.infrastructure.install_python
     - role: mirsg.infrastructure.docker
     - role: mirsg.infrastructure.firewalld

--- a/roles/docker/tasks/client-certs.yml
+++ b/roles/docker/tasks/client-certs.yml
@@ -9,40 +9,42 @@
 
 - name: Generate OpenSSL client private key
   community.crypto.openssl_privatekey:
-    path: "{{ docker_client_certificate_directory }}/key.pem"
+    path: "{{ docker_client_certificate_directory }}/{{ client_hostname }}.pem"
     owner: "{{ docker_owner }}"
     group: "{{ docker_group }}"
     mode: "0400"
 
-- name: Generate OpenSSL CSR for each client using private key
+- name: Generate OpenSSL CSR for client using private key
   community.crypto.openssl_csr:
-    path: "{{ docker_client_certificate_directory }}/{{ item }}.csr"
-    privatekey_path: "{{ docker_client_certificate_directory }}/key.pem"
-    common_name: "{{ item }}"
+    path: "{{ docker_client_certificate_directory }}/{{ client_hostname }}.csr"
+    privatekey_path:
+      "{{ docker_client_certificate_directory }}/{{ client_hostname }}.pem"
+    common_name: "{{ client_hostname }}"
   register: new_docker_client_csr_generated
-  loop: "{{ docker_client_hostnames }}"
 
-- name: Generate client certificates signed by server CA
+- name: Generate client certificate signed by server CA
   community.crypto.x509_certificate:
-    path: "{{ docker_client_certificate_directory }}/{{ item }}.cert"
-    csr_path: "{{ docker_client_certificate_directory }}/{{ item }}.csr"
+    path: "{{ docker_client_certificate_directory }}/{{ client_hostname }}.cert"
+    csr_path:
+      "{{ docker_client_certificate_directory }}/{{ client_hostname }}.csr"
     provider: ownca
     ownca_path: "{{ docker_ca_cert }}"
     ownca_privatekey_path: "{{ docker_ca_key }}"
     mode: "0400"
     owner: "{{ docker_owner }}"
     group: "{{ docker_group }}"
-  loop: "{{ docker_client_hostnames }}"
 
-- name: Copy signed client certificates to temp dir on Ansible controller
+- name: Copy signed client certificate to temp dir on Ansible controller
   ansible.builtin.fetch:
-    src: "{{ docker_client_certificate_directory }}/{{ item }}.cert"
-    dest: "{{ docker_client_certificate_cache_directory }}/{{ item }}.cert"
+    src: "{{ docker_client_certificate_directory }}/{{ client_hostname }}.cert"
+    dest:
+      "{{ docker_client_certificate_cache_directory }}/{{ client_hostname
+      }}.cert"
     flat: true
-  loop: "{{ docker_client_hostnames }}"
 
 - name: Copy private key to temp dir on Ansible controller
   ansible.builtin.fetch:
-    src: "{{ docker_client_certificate_directory }}/key.pem"
-    dest: "{{ docker_client_certificate_cache_directory }}/key.pem"
+    src: "{{ docker_client_certificate_directory }}/{{ client_hostname }}.pem"
+    dest:
+      "{{ docker_client_certificate_cache_directory }}/{{ client_hostname }}.pem"
     flat: true

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -88,8 +88,11 @@
       ansible.builtin.import_tasks: server-cert.yml
 
     - name: Generate TLS certificates for each client
-      ansible.builtin.import_tasks: client-certs.yml
+      ansible.builtin.include_tasks: client-certs.yml
       when: docker_client_hostnames
+      vars:
+        client_hostname: "{{ item }}"
+      loop: "{{ docker_client_hostnames }}"
 
 - name:
     Ensure docker service configuration is reloaded before restarting the

--- a/roles/firewalld/tasks/main.yml
+++ b/roles/firewalld/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
 # tasks file for ../ansible-role-firewalld
+- name: Install firewalld
+  ansible.builtin.package:
+    name: firewalld
+    state: present
+
 - name: Make sure firewalld service is enabled
   ansible.builtin.systemd:
     name: firewalld

--- a/roles/provision/tasks/check_mounts.yml
+++ b/roles/provision/tasks/check_mounts.yml
@@ -1,14 +1,14 @@
 ---
 - name: Ensure correct permissions are set for the mountpoint
   ansible.builtin.file:
-    path: "{{ external_storage_drive }}"
+    path: "{{ mount_point }}"
     owner: root
     group: root
     state: directory
     mode: "0755"
 
-- name: "Check if storage is mounted: {{ external_storage_drive }}"
-  ansible.builtin.command: mountpoint {{ external_storage_drive }}
+- name: "Check if storage is mounted: {{ mount_point }}"
+  ansible.builtin.command: mountpoint {{ mount_point }}
   register: check_mountpoint
   failed_when: false
   changed_when: false
@@ -22,7 +22,7 @@
 - name:
     Check that storage has been mounted correctly if it was previously not
     mounted
-  ansible.builtin.command: mountpoint {{ external_storage_drive }}
+  ansible.builtin.command: mountpoint {{ mount_point }}
   when: "'is not a mountpoint' in check_mountpoint.stdout"
   register: check_mountpoint_again
   failed_when: "'is not a mountpoint' in check_mountpoint_again.stdout"

--- a/roles/provision/tasks/main.yml
+++ b/roles/provision/tasks/main.yml
@@ -2,7 +2,9 @@
 - name: Check mounts are available
   tags: restart
   ansible.builtin.include_tasks: check_mounts.yml
-  when: external_storage_drive is defined
+  vars:
+    mount_point: "{{ item }}"
+  loop: "{{ provision_mount_points }}"
 
 - name: Set up for RedHat 7
   ansible.builtin.include_tasks: RedHat7.yml

--- a/roles/xnat_container_service/tasks/add_container_service_hub.yml
+++ b/roles/xnat_container_service/tasks/add_container_service_hub.yml
@@ -1,0 +1,29 @@
+---
+- name: Check if Image Host
+  ansible.builtin.uri:
+    url:
+      "{{ web_server.url }}/xapi/docker/hubs/{{ container_registry.name |
+      urlencode }}"
+    user: "{{ xnat_service_admin.username }}"
+    password: "{{ xnat_service_admin.password }}"
+    method: GET
+    validate_certs: "{{ ssl.validate_certs }}"
+    status_code: 200, 404
+  register: hub_check
+
+- name: Configure Image Host
+  ansible.builtin.uri:
+    url: "{{ web_server.url }}/xapi/docker/hubs"
+    user: "{{ xnat_service_admin.username }}"
+    password: "{{ xnat_service_admin.password }}"
+    method: POST
+    body_format: json
+    body:
+      name: "{{ container_registry.name }}"
+      url: "{{ container_registry.url }}"
+      username: "{{ container_registry.username }}"
+      password: "{{ container_registry.password }}"
+      default: "{{ container_registry.default }}"
+    validate_certs: "{{ ssl.validate_certs }}"
+    status_code: 200, 201
+  when: hub_check.status != 200

--- a/roles/xnat_container_service/tasks/main.yml
+++ b/roles/xnat_container_service/tasks/main.yml
@@ -57,3 +57,10 @@
       container-user: ""
     validate_certs: "{{ xnat_container_service_validate_certs }}"
     status_code: 200, 201
+
+- name: Set up container service registries
+  ansible.builtin.include_tasks: add_container_service_hub.yml
+  vars:
+    container_registry: "{{ item }}"
+  loop: "{{ xnat_container_service_hubs | default([]) }}"
+  when: external_storage_drive is defined

--- a/roles/xnat_container_service/tasks/main.yml
+++ b/roles/xnat_container_service/tasks/main.yml
@@ -29,7 +29,9 @@
 
 - name: Copy private key from Ansible Controller cache to client
   ansible.builtin.copy:
-    src: "{{ xnat_container_service_certificate_cache_directory }}/key.pem"
+    src:
+      "{{ xnat_container_service_certificate_cache_directory }}/{{
+      xnat_container_service_client_hostname }}.pem"
     dest: "{{ xnat_container_service_key }}"
     owner: "{{ xnat_container_service_owner }}"
     group: "{{ xnat_container_service_group }}"


### PR DESCRIPTION
Adds support for a container service to serve multiple XNAT clients.

The main change is modifying the provision role to allow multiple mounts, as the container server will have one for each XNAT server. The mount points are now defined in a list `container_service_mounts`. However, this defaults to a list containing the single entry `external_storage_drive`, which should preserve existing behaviour.

The container service client role will now set up the Docker image hosts, which can be set in the Ansible variables.

Fixed an issue with the Docker client key filenames. They were not given unique names, which would have caused them to overwrite each other if the server had more than one client.



