### PR TITLE
Update container service

### DIFF
--- a/roles/firewalld/tasks/main.yml
+++ b/roles/firewalld/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
 # tasks file for ../ansible-role-firewalld
+- name: Install firewalld
+  ansible.builtin.package:
+    name: firewalld
+    state: present
+
 - name: Make sure firewalld service is enabled
   ansible.builtin.systemd:
     name: firewalld

--- a/roles/provision/README.md
+++ b/roles/provision/README.md
@@ -24,10 +24,11 @@ The following variables can be set for provisioning Rocky 8+:
 
 The following variables can be set for either CentOS 7 or Rocky 8+:
 
-| Name                     | Description                                                          |
-| ------------------------ | -------------------------------------------------------------------- |
-| `server_locale`          | sets the user's language, region, etc. This is set to "en_GB.UTF-8"  |
-| `external_storage_drive` | path to mounted storage (if using it). By default this is undefined. |
+| Name                      | Description                                                                                        |
+| ------------------------- | -------------------------------------------------------------------------------------------------- |
+| `server_locale`           | sets the user's language, region, etc. This is set to "en_GB.UTF-8"                                |
+| `external_storage_drive`  | single path to mounted storage (if using it). By default this is undefined.                        |
+| `external_storage_mounts` | list of paths to mounted storage (if using multiple storage mounts). By default this is undefined. |
 
 ## Dependencies
 

--- a/roles/provision/defaults/main.yml
+++ b/roles/provision/defaults/main.yml
@@ -11,3 +11,6 @@ postgresql_rpm_gpg_key_pgdg_x86_64: >-
 postgresql_rpm_gpg_key_pgdg_aarch64: >-
   https://apt.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-AARCH64-RHEL
 server_locale: en_GB.UTF-8
+provision_mount_points:
+  "{{ external_storage_mounts | default([external_storage_drive] if
+  external_storage_drive is defined else []) }}"

--- a/roles/provision/tasks/check_mounts.yml
+++ b/roles/provision/tasks/check_mounts.yml
@@ -1,14 +1,14 @@
 ---
 - name: Ensure correct permissions are set for the mountpoint
   ansible.builtin.file:
-    path: "{{ external_storage_drive }}"
+    path: "{{ mount_point }}"
     owner: root
     group: root
     state: directory
     mode: "0755"
 
-- name: "Check if storage is mounted: {{ external_storage_drive }}"
-  ansible.builtin.command: mountpoint {{ external_storage_drive }}
+- name: "Check if storage is mounted: {{ mount_point }}"
+  ansible.builtin.command: mountpoint {{ mount_point }}
   register: check_mountpoint
   failed_when: false
   changed_when: false
@@ -22,7 +22,7 @@
 - name:
     Check that storage has been mounted correctly if it was previously not
     mounted
-  ansible.builtin.command: mountpoint {{ external_storage_drive }}
+  ansible.builtin.command: mountpoint {{ mount_point }}
   when: "'is not a mountpoint' in check_mountpoint.stdout"
   register: check_mountpoint_again
   failed_when: "'is not a mountpoint' in check_mountpoint_again.stdout"

--- a/roles/provision/tasks/main.yml
+++ b/roles/provision/tasks/main.yml
@@ -2,7 +2,9 @@
 - name: Check mounts are available
   tags: restart
   ansible.builtin.include_tasks: check_mounts.yml
-  when: external_storage_drive is defined
+  vars:
+    mount_point: "{{ item }}"
+  loop: "{{ provision_mount_points }}"
 
 - name: Set up for RedHat 7
   ansible.builtin.include_tasks: RedHat7.yml

--- a/roles/xnat/tasks/plugins.yml
+++ b/roles/xnat/tasks/plugins.yml
@@ -40,7 +40,9 @@
     owner: "{{ xnat.owner }}"
     group: "{{ xnat.group }}"
     verify_checksum: always
-    headers: "{{ package_registry.authentication_header }}"
+    headers: "{{ package_registry.authentication_header | default(omit) }}"
+    username: "{{ package_registry.username | default(omit) }}"
+    password: "{{ package_registry.token | default(omit) }}"
   register: package_plugins_downloaded
   with_items:
     - "{{ xnat_plugin_packages | default([]) }}"

--- a/roles/xnat_container_service/tasks/add_container_service_hub.yml
+++ b/roles/xnat_container_service/tasks/add_container_service_hub.yml
@@ -1,0 +1,29 @@
+---
+- name: Check if Image Host already configured
+  ansible.builtin.uri:
+    url:
+      "{{ web_server.url }}/xapi/docker/hubs/{{ container_registry.name |
+      urlencode }}"
+    user: "{{ xnat_service_admin.username }}"
+    password: "{{ xnat_service_admin.password }}"
+    method: GET
+    validate_certs: "{{ ssl.validate_certs }}"
+    status_code: 200, 404
+  register: hub_check
+
+- name: Configure Image Host
+  ansible.builtin.uri:
+    url: "{{ web_server.url }}/xapi/docker/hubs"
+    user: "{{ xnat_service_admin.username }}"
+    password: "{{ xnat_service_admin.password }}"
+    method: POST
+    body_format: json
+    body:
+      name: "{{ container_registry.name }}"
+      url: "{{ container_registry.url }}"
+      username: "{{ container_registry.username }}"
+      password: "{{ container_registry.password }}"
+      default: "{{ container_registry.default }}"
+    validate_certs: "{{ ssl.validate_certs }}"
+    status_code: 200, 201
+  when: hub_check.status != 200

--- a/roles/xnat_container_service/tasks/main.yml
+++ b/roles/xnat_container_service/tasks/main.yml
@@ -57,3 +57,10 @@
       container-user: ""
     validate_certs: "{{ xnat_container_service_validate_certs }}"
     status_code: 200, 201
+
+- name: Set up container service registries
+  ansible.builtin.include_tasks: add_container_service_hub.yml
+  vars:
+    container_registry: "{{ item }}"
+  loop: "{{ xnat_container_service_hubs | default([]) }}"
+  when: external_storage_drive is defined


### PR DESCRIPTION
Adds support for a container service to serve multiple XNAT clients.

The main change is modifying the provision role to allow checking of multiple mount points. Previously only a single mount point was supported, but a container server may have a separate mount for each server it supports.

Multiple mount points can be configured by defining the list `external_storage_mounts` in the host variables for the container server. If not set, the default will fall back to a list containing the single entry `external_storage_drive`, or an empty list if this is not set. This preserves existing behaviour.

The container service client role will now configure the XNAT container service "Docker image hosts" (aka hubs) from which containers can be pulled to run on XNAT. These can be defined in the Ansible variables.

In addition, I've added two optional changes to facilitate local testing:
- Allow optional use of the GitHub package registry instead of JFrog, by permitting maven_artifact to optionally use username/password authentication instead of an authentication header. This preserves existing behaviour but permits switching to a package registry with a different authentication mechanism if appropriately configured in the ansible variables
- Install firewalld package as part of the firewall role if it is not present

