### PR TITLE
Update default `xnat_version`

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -60,6 +60,19 @@
     mode: "0644"
   notify: Reload docker
 
+- name: Generate CA, server, and client certificates
+  when: docker_generate_certificates
+  block:
+    - name: Generate CA certificate
+      ansible.builtin.import_tasks: ca-cert.yml
+
+    - name: Generate server TLS certificate
+      ansible.builtin.import_tasks: server-cert.yml
+
+    - name: Generate TLS certificates for each client
+      ansible.builtin.import_tasks: client-certs.yml
+      when: docker_client_hostnames
+
 - name: Ensure docker config directory exists - {{ docker_config_dir }}
   ansible.builtin.file:
     path: "{{ docker_config_dir }}"
@@ -75,21 +88,8 @@
     owner: "{{ docker_owner }}"
     group: "{{ docker_group }}"
     mode: "0640"
-
-- name: Generate CA, server, and client certificates
-  when: docker_generate_certificates
   notify:
     - Restart docker
-  block:
-    - name: Generate CA certificate
-      ansible.builtin.import_tasks: ca-cert.yml
-
-    - name: Generate server TLS certificate
-      ansible.builtin.import_tasks: server-cert.yml
-
-    - name: Generate TLS certificates for each client
-      ansible.builtin.import_tasks: client-certs.yml
-      when: docker_client_hostnames
 
 - name:
     Ensure docker service configuration is reloaded before restarting the

--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-xnat_version: 1.9.1
+xnat_version: 1.9.1.1
 xnat_pipeline_version: 1.8.10
 xnat_archive_dir: "{{ xnat_root_dir }}/archive"
 xnat_prearchive_dir: "{{ xnat_root_dir }}/prearchive"
@@ -41,7 +41,7 @@ xnat_ldap_keystore_alias: ""
 xnat_plugin_urls:
   - https://api.bitbucket.org/2.0/repositories/xnatdev/xsync/downloads/xsync-plugin-all-1.8.1.jar
   - https://api.bitbucket.org/2.0/repositories/xnatx/ldap-auth-plugin/downloads/ldap-auth-plugin-1.2.1.jar
-  - https://api.bitbucket.org/2.0/repositories/xnatdev/container-service/downloads/container-service-3.6.1-fat.jar
+  - https://api.bitbucket.org/2.0/repositories/xnatdev/container-service/downloads/container-service-3.6.2-fat.jar
   - https://api.bitbucket.org/2.0/repositories/xnatx/xnatx-batch-launch-plugin/downloads/batch-launch-0.7.0.jar
   - https://github.com/VUIIS/dax/raw/main/misc/xnat-plugins/dax-plugin-genProcData-1.4.2.jar
   - https://api.bitbucket.org/2.0/repositories/icrimaginginformatics/ohif-viewer-xnat-plugin/downloads/ohif-viewer-3.7.0-XNAT-1.8.10.jar

--- a/roles/xnat_container_service/tasks/main.yml
+++ b/roles/xnat_container_service/tasks/main.yml
@@ -16,8 +16,8 @@
         tcp://{{ xnat_container_service_hostname }}:{{
         xnat_container_service_port }}
       cert-path:
-        "{{ xnat_container_service_certificate_directory }} if {{
-        xnat_container_service_use_ssl }} else ''"
+        "{{ xnat_container_service_certificate_directory if
+        xnat_container_service_use_ssl else '' }}"
       swarm-mode: false
       path-translation-xnat-prefix:
         "{{ xnat_container_service_path_translation_xnat_prefix }}"


### PR DESCRIPTION
- update default `xnat_version` to 1.9.1.1
- update plugins
- always restart docker after setting the daemon configuration (currently is `docker_generate_certs` is false, the daemon is not restarted and so any changes to the configuration are not applied)
