### PR TITLE
Downgrade LDAP plugin to 1.1.0

### DIFF
--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -40,7 +40,7 @@ xnat_ldap_keystore_alias: ""
 # Plugins
 xnat_plugin_urls:
   - https://api.bitbucket.org/2.0/repositories/xnatdev/xsync/downloads/xsync-plugin-all-1.8.1.jar
-  - https://api.bitbucket.org/2.0/repositories/xnatx/ldap-auth-plugin/downloads/ldap-auth-plugin-1.2.1.jar
+  - https://api.bitbucket.org/2.0/repositories/xnatx/ldap-auth-plugin/downloads/ldap-auth-plugin-1.1.0.jar
   - https://api.bitbucket.org/2.0/repositories/xnatdev/container-service/downloads/container-service-3.6.2-fat.jar
   - https://api.bitbucket.org/2.0/repositories/xnatx/xnatx-batch-launch-plugin/downloads/batch-launch-0.7.0.jar
   - https://github.com/VUIIS/dax/raw/main/misc/xnat-plugins/dax-plugin-genProcData-1.4.2.jar


### PR DESCRIPTION
- there's an issue with 1.2.1 in which the LDAP plugin attempts to login as a different user to the one specified on the login screen (the user LDAP attempts to login with is always the same, regardless of the user logging in). Downgrading to 1.1.0 seems to resolve this issue