### PR TITLE
Add support for docker swarm mode

### DIFF
--- a/playbooks/molecule/resources/xnat/inventory/group_vars/centos7.yml
+++ b/playbooks/molecule/resources/xnat/inventory/group_vars/centos7.yml
@@ -10,3 +10,4 @@ install_python:
     - python-setuptools
   pip_packages:
     - cryptography
+    - requests

--- a/playbooks/molecule/resources/xnat/inventory/group_vars/centos7.yml
+++ b/playbooks/molecule/resources/xnat/inventory/group_vars/centos7.yml
@@ -10,4 +10,4 @@ install_python:
     - python-setuptools
   pip_packages:
     - cryptography
-    - requests
+    - docker

--- a/playbooks/molecule/resources/xnat/inventory/group_vars/container_service.yml
+++ b/playbooks/molecule/resources/xnat/inventory/group_vars/container_service.yml
@@ -6,3 +6,4 @@ docker_client_certificate_cache_directory:
 docker_server_hostname: "{{ hostvars['xnat_cserv']['hostname'] }}"
 docker_server_ip: "{{ hostvars['xnat_cserv']['ansible_ip'] }}"
 docker_server_port: 2376
+docker_swarm_enabled: true

--- a/playbooks/molecule/resources/xnat/inventory/group_vars/container_service_client.yml
+++ b/playbooks/molecule/resources/xnat/inventory/group_vars/container_service_client.yml
@@ -6,7 +6,6 @@ xnat_container_service_client_hostname: "{{ hostvars['xnat_web']['hostname'] }}"
 xnat_container_service_validate_certs: "{{ ssl.validate_certs }}"
 
 xnat_container_service_hostname: "{{ docker_server_hostname }}"
-xnat_container_service_ip: "{{ docker_service_ip }}"
 xnat_container_service_port: "{{ docker_server_port }}"
 xnat_container_service_certificate_cache_directory:
   "{{ docker_client_certificate_cache_directory }}"

--- a/playbooks/molecule/resources/xnat/inventory/group_vars/container_service_client.yml
+++ b/playbooks/molecule/resources/xnat/inventory/group_vars/container_service_client.yml
@@ -13,3 +13,5 @@ xnat_container_service_certificate_cache_directory:
 
 xnat_container_service_path_translation_xnat_prefix: "{{ xnat_root_dir }}"
 xnat_container_service_path_translation_docker_prefix: /storage/xnat/data/xnat
+
+xnat_container_service_swarm_mode: "{{ docker_swarm_enabled }}"

--- a/playbooks/molecule/resources/xnat/inventory/group_vars/rocky9.yml
+++ b/playbooks/molecule/resources/xnat/inventory/group_vars/rocky9.yml
@@ -10,4 +10,4 @@ install_python:
     - python3-setuptools
   pip_packages:
     - cryptography
-    - requests
+    - docker

--- a/playbooks/molecule/resources/xnat/inventory/group_vars/rocky9.yml
+++ b/playbooks/molecule/resources/xnat/inventory/group_vars/rocky9.yml
@@ -10,3 +10,4 @@ install_python:
     - python3-setuptools
   pip_packages:
     - cryptography
+    - requests

--- a/roles/docker/README.md
+++ b/roles/docker/README.md
@@ -15,6 +15,7 @@ on CentOS 7 or Rocky Linux 8.
 | `docker_rpm_gpg_key_url`   | The url of the Docker repository GPG key. Defaults to `https://download.docker.com/linux/centos/gpg` |
 | `docker_repo_baseurl`      | URL to the directory containing the repodata. Defaults to `https://download.docker.com/linux/centos` |
 | `docker_yum_package`       | The name of the Docker package. Defaults to `docker`                                                 |
+| `docker_swarm_enabled`     | Initialise a [Docker Swarm](https://docs.docker.com/engine/swarm/). Defaults to `false`.             |
 
 If you would like to
 [configure](https://docs.docker.com/engine/security/protect-access/#use-tls-https-to-protect-the-docker-daemon-socket)

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -41,3 +41,6 @@ docker_client_certificate_directory:
   "{{ docker_certificate_directory }}/client_certs"
 docker_client_certificate_cache_directory:
   "{{ lookup('env', 'HOME') }}/ansible_persistent_files/docker_certificates"
+
+# Swarm mode
+docker_swarm_enabled: false

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -106,5 +106,5 @@
   community.docker.docker_swarm:
     state: present
     advertise_addr: "{{ docker_server_ip }}:{{ docker_server_port }}"
-    listen_addr: "{{ docker_server_ip }}:{{ docker_server_port }}"
+    listen_addr: "{{ docker_server_ip }}"
   when: docker_swarm_enabled

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -105,6 +105,4 @@
 - name: Initialize Docker Swarm
   community.docker.docker_swarm:
     state: present
-    advertise_addr: "{{ docker_server_ip }}:{{ docker_server_port }}"
-    listen_addr: "{{ docker_server_ip }}"
   when: docker_swarm_enabled

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -101,3 +101,10 @@
     name: "{{ docker_service_name }}"
     state: started
     enabled: true
+
+- name: Initialize Docker Swarm
+  community.docker.docker_swarm:
+    state: present
+    advertise_addr: "{{ docker_server_ip }}:{{ docker_server_port }}"
+    listen_addr: "{{ docker_server_ip }}:{{ docker_server_port }}"
+  when: docker_swarm_enabled

--- a/roles/xnat_container_service/tasks/main.yml
+++ b/roles/xnat_container_service/tasks/main.yml
@@ -18,7 +18,8 @@
       cert-path:
         "{{ xnat_container_service_certificate_directory if
         xnat_container_service_use_ssl else '' }}"
-      backend: swarm if {{ xnat_container_service_swarm_mode }} else docker
+      backend:
+        "{{ 'swarm' if xnat_container_service_swarm_mode else 'docker' }}"
       swarm-mode: "{{ xnat_container_service_swarm_mode }}"
       max-concurrent-finalizing-jobs: 1
       path-translation-xnat-prefix:

--- a/roles/xnat_container_service/tasks/main.yml
+++ b/roles/xnat_container_service/tasks/main.yml
@@ -18,7 +18,9 @@
       cert-path:
         "{{ xnat_container_service_certificate_directory if
         xnat_container_service_use_ssl else '' }}"
-      swarm-mode: false
+      backend: swarm if {{ xnat_container_service_swarm_mode }} else docker
+      swarm-mode: "{{ xnat_container_service_swarm_mode }}"
+      max-concurrent-finalizing-jobs: 1
       path-translation-xnat-prefix:
         "{{ xnat_container_service_path_translation_xnat_prefix }}"
       path-translation-docker-prefix:


### PR DESCRIPTION
Fixes #148 

- add variable `docker_swarm_enabled` to the `mirsg.docker` role. If `true`, will use `community.docker.docker_swarm` to initialise a swarm on the docker host
- add variable `xnat_container_service_swarm_mode`. If `true`, the Container Service will be configured to run with Docker Swarm mode