### PR TITLE
Update tomcat version to latest in defaults and examples

### DIFF
--- a/playbooks/group_vars/xnat.yml
+++ b/playbooks/group_vars/xnat.yml
@@ -21,7 +21,7 @@ xnat_source:
   context_file_location: /usr/share/tomcat/webapps/ROOT/META-INF/context.xml
 
 # mirsg.infrastructure.tomcat
-tomcat_version: 9.0.104
+tomcat_version: 9.0.106
 tomcat_owner: tomcat
 tomcat_group: tomcat
 

--- a/roles/tomcat/defaults/main.yml
+++ b/roles/tomcat/defaults/main.yml
@@ -7,7 +7,7 @@ java_home: /usr/lib/jvm/jre
 java_profile_d: /etc/profile.d
 
 # mirsg.tomcat
-tomcat_version: 9.0.97
+tomcat_version: 9.0.106
 tomcat_owner: tomcat
 tomcat_group: tomcat
 

--- a/roles/tomcat/molecule/resources/inventory/group_vars/tomcat10.yml
+++ b/roles/tomcat/molecule/resources/inventory/group_vars/tomcat10.yml
@@ -1,2 +1,2 @@
 ---
-tomcat_version: 10.1.19
+tomcat_version: 10.1.42


### PR DESCRIPTION
Related to #175, it looks like tomcat version isn't being updated in defaults. This is an issue for [UCL-MIRSG/UCLMedicalImagingEnv](http://github.com/UCL-MIRSG/UCLMedicalImagingEnv) as there is no `tomcat_version` defined there so it will pull the wrong/default version from the role.