### PR TITLE
Updated XNAT-OHIF jar source

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -22,7 +22,7 @@
     {
       customType: "regex",
       description: "Update Tomcat version specified in playbooks/group_vars/xnat.yml",
-      fileMatch: ["(^|/)*xnat.yml$"],
+      managerFilePatterns: ["/(^|/)*xnat.yml$/"],
       matchStrings: ["tomcat_version:\\s?(?<currentValue>.*?)\\n"],
       depNameTemplate: "org.apache.tomcat:tomcat",
       datasourceTemplate: "maven",
@@ -30,7 +30,7 @@
     {
       customType: "regex",
       description: "Update XNAT version specified in roles/xnat/defaults/main.yml",
-      fileMatch: ["(^|/)*defaults/main.yml$"],
+      managerFilePatterns: ["/(^|/)*defaults/main.yml$/"],
       matchStrings: ["xnat_version:\\s?(?<currentValue>.*?)\\n"],
       depNameTemplate: "xnatdev/xnat-web",
       datasourceTemplate: "bitbucket-tags",
@@ -38,7 +38,7 @@
     {
       customType: "regex",
       description: "Update XNAT-sync plugin version specified in roles/xnat/defaults/main.yml",
-      fileMatch: ["roles/xnat/defaults/main.yml$"],
+      managerFilePatterns: ["/roles/xnat/defaults/main.yml$/"],
       matchStrings: ["xsync-plugin-all-(?<currentValue>.*?).jar"],
       depNameTemplate: "xnatdev/xsync",
       datasourceTemplate: "bitbucket-tags",
@@ -46,7 +46,7 @@
     {
       customType: "regex",
       description: "Update XNAT ldap-auth plugin version specified in roles/xnat/defaults/main.yml",
-      fileMatch: ["roles/xnat/defaults/main.yml$"],
+      managerFilePatterns: ["/roles/xnat/defaults/main.yml$/"],
       matchStrings: ["ldap-auth-plugin-(?<currentValue>.*?).jar"],
       depNameTemplate: "xnatx/ldap-auth-plugin",
       datasourceTemplate: "bitbucket-tags",
@@ -54,7 +54,7 @@
     {
       customType: "regex",
       description: "Update OHIF Viewer plugin version specified in roles/xnat/defaults/main.yml",
-      fileMatch: ["roles/xnat/defaults/main.yml$"],
+      managerFilePatterns: ["/roles/xnat/defaults/main.yml$/"],
       matchStrings: ["ohif-viewer-(?<currentValue>.*?).jar"],
       depNameTemplate: "icrimaginginformatics/ohif-viewer-xnat-plugin",
       datasourceTemplate: "bitbucket-tags",
@@ -62,7 +62,7 @@
     {
       customType: "regex",
       description: "Update XNAT ML plugin version specified in roles/xnat/defaults/main.yml",
-      fileMatch: ["roles/xnat/defaults/main.yml$"],
+      managerFilePatterns: ["/roles/xnat/defaults/main.yml$/"],
       matchStrings: ["ml-plugin-(?<currentValue>.*?).jar"],
       depNameTemplate: "xnatx/ml-plugin",
       datasourceTemplate: "bitbucket-tags",
@@ -70,7 +70,7 @@
     {
       customType: "regex",
       description: "Update XNAT datasets plugin version specified in roles/xnat/defaults/main.yml",
-      fileMatch: ["roles/xnat/defaults/main.yml$"],
+      managerFilePatterns: ["/roles/xnat/defaults/main.yml$/"],
       matchStrings: ["datasets-plugin-(?<currentValue>.*?).jar"],
       depNameTemplate: "xnatx/datasets-plugin",
       datasourceTemplate: "bitbucket-tags",
@@ -78,7 +78,7 @@
     {
       customType: "regex",
       description: "Update XNAT image viewer plugin version specified in roles/xnat/defaults/main.yml",
-      fileMatch: ["roles/xnat/defaults/main.yml$"],
+      managerFilePatterns: ["/roles/xnat/defaults/main.yml$/"],
       matchStrings: ["ximgview-plugin(?<currentValue>.*?).jar"],
       depNameTemplate: "xnatdev/xnat-image-viewer-plugin",
       datasourceTemplate: "bitbucket-tags",
@@ -86,7 +86,7 @@
     {
       customType: "regex",
       description: "Update XNAT dxm plugin version specified in roles/xnat/defaults/main.yml",
-      fileMatch: ["roles/xnat/defaults/main.yml$"],
+      managerFilePatterns: ["/roles/xnat/defaults/main.yml$/"],
       matchStrings: ["dxm-settings-plugin-(?<currentValue>.*?).jar"],
       depNameTemplate: "xnatx/xnatx-dxm-settings-plugin",
       datasourceTemplate: "bitbucket-tags",
@@ -94,7 +94,7 @@
     {
       customType: "regex",
       description: "Update XNAT pipeline version specified in roles/xnat/defaults/main.yml",
-      fileMatch: ["(^|/)*defaults/main.yml$"],
+      managerFilePatterns: ["/(^|/)*defaults/main.yml$/"],
       matchStrings: ["xnat_pipeline_version:\\s?(?<currentValue>.*?)\\n"],
       depNameTemplate: "NrgXnat/xnat-pipeline-engine",
       datasourceTemplate: "github-releases",
@@ -102,8 +102,8 @@
     {
       customType: "regex",
       description: "Update XNAT Container Service plugin version used for testing with molecule",
-      fileMatch: [
-        "playbooks/molecule/resources/xnat/inventory/group_vars/all/server.yml$",
+      managerFilePatterns: [
+        "/playbooks/molecule/resources/xnat/inventory/group_vars/all/server.yml$/",
       ],
       matchStrings: ["container-service-(?<currentValue>.*?)-fat.jar"],
       depNameTemplate: "xnatdev/container-service",
@@ -112,8 +112,8 @@
     {
       customType: "regex",
       description: "Update XNAT batch launch plugin version used for testing with molecule",
-      fileMatch: [
-        "playbooks/molecule/resources/xnat/inventory/group_vars/all/server.yml$",
+      managerFilePatterns: [
+        "/playbooks/molecule/resources/xnat/inventory/group_vars/all/server.yml$/",
       ],
       matchStrings: ["batch-launch-(?<currentValue>.*?).jar"],
       depNameTemplate: "xnatx/xnatx-batch-launch-plugin",
@@ -122,8 +122,8 @@
     {
       customType: "regex",
       description: "Update XNAT dax plugin used for testing with molecule",
-      fileMatch: [
-        "playbooks/molecule/resources/xnat/inventory/group_vars/all/server.yml$",
+      managerFilePatterns: [
+        "/playbooks/molecule/resources/xnat/inventory/group_vars/all/server.yml$/",
       ],
       matchStrings: ["dax-plugin-genProcData-(?<currentValue>.*?).jar"],
       depNameTemplate: "VUIIS/dax",

--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -41,7 +41,7 @@ xnat_ldap_keystore_alias: ""
 xnat_plugin_urls:
   - https://api.bitbucket.org/2.0/repositories/xnatdev/xsync/downloads/xsync-plugin-all-1.8.1.jar
   - https://api.bitbucket.org/2.0/repositories/xnatx/ldap-auth-plugin/downloads/ldap-auth-plugin-1.2.1.jar
-  - https://api.bitbucket.org/2.0/repositories/icrimaginginformatics/ohif-viewer-xnat-plugin/downloads/ohif-viewer-3.7.0-XNAT-1.8.10.jar
+  - https://www.xnat.org/files/ohif-viewer-xnat-plugin/ohif-viewer-3.7.1-fat.jar
   - https://api.bitbucket.org/2.0/repositories/xnatx/ml-schema-plugin/downloads/ml-schema-plugin-1.0.0.jar
   - https://api.bitbucket.org/2.0/repositories/xnatx/datasets-schema-plugin/downloads/datasets-schema-plugin-1.0.0.jar
   - https://api.bitbucket.org/2.0/repositories/xnatdev/xnat-image-viewer-plugin/downloads/ximgview-plugin-1.0.2.jar


### PR DESCRIPTION
https://github.com/UCL-MIRSG/UCLMedicalImagingEnv/issues/461 means that any playbook that tries to access the ICR XNAT-OHIF Bitbucket repo will fail.

This is leading to:
- https://github.com/UCL-MIRSG/UCLMedicalImagingEnv/issues/462
- CI/CD failures in this repo - e.g. https://github.com/UCL-MIRSG/ansible-collection-infra/actions/runs/15974112940?pr=176

This PR updates the source URL used to https://xnat.org/files/ohif-viewer-xnat-plugin/ohif-viewer-3.7.1-fat.jar