### PR TITLE
Ensure crypto collection is v2.x.x

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -45,7 +45,7 @@ dependencies:
   "ansible.posix": ">=1.5.4"
   "community.postgresql": ">=3.0.0"
   "community.docker": ">=3.4.8"
-  "community.crypto": ">=2.14.1"
+  "community.crypto": ">=2.14.1,<3.0.0"
 
 # The URL of the originating SCM repository
 repository: https://github.com/UCL-MIRSG/ansible-collection-infra


### PR DESCRIPTION
Resolves #180 by specifying that the collection requires ansible.community.crypto < 3.0.0