### PR TITLE
Update default `xnat_version` to 1.9.2.1

### DIFF
--- a/playbooks/molecule/resources/xnat/inventory/group_vars/all/server.yml
+++ b/playbooks/molecule/resources/xnat/inventory/group_vars/all/server.yml
@@ -38,6 +38,6 @@ xnat_config:
   admin_password: "{{ vault_admin_password }}"
 
 xnat_server_specific_plugin_urls:
-  - https://api.bitbucket.org/2.0/repositories/xnatdev/container-service/downloads/container-service-3.6.3-fat.jar
-  - https://api.bitbucket.org/2.0/repositories/xnatx/xnatx-batch-launch-plugin/downloads/batch-launch-0.7.0.jar
+  - https://api.bitbucket.org/2.0/repositories/xnatdev/container-service/downloads/container-service-3.7.1-fat.jar
+  - https://api.bitbucket.org/2.0/repositories/xnatx/xnatx-batch-launch-plugin/downloads/batch-launch-0.8.0-xpl.jar
   - https://github.com/VUIIS/dax/raw/main/misc/xnat-plugins/dax-plugin-genProcData-1.4.2.jar

--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-xnat_version: 1.9.1.2
+xnat_version: 1.9.2.1
 xnat_pipeline_version: 1.8.10
 xnat_archive_dir: "{{ xnat_root_dir }}/archive"
 xnat_prearchive_dir: "{{ xnat_root_dir }}/prearchive"
@@ -40,7 +40,7 @@ xnat_ldap_keystore_alias: ""
 # Plugins
 xnat_plugin_urls:
   - https://api.bitbucket.org/2.0/repositories/xnatdev/xsync/downloads/xsync-plugin-all-1.8.1.jar
-  - https://api.bitbucket.org/2.0/repositories/xnatx/ldap-auth-plugin/downloads/ldap-auth-plugin-1.2.1.jar
+  - https://api.bitbucket.org/2.0/repositories/xnatx/ldap-auth-plugin/downloads/ldap-auth-plugin-1.1.0.jar
   - https://www.xnat.org/files/ohif-viewer-xnat-plugin/ohif-viewer-3.7.1-fat.jar
   - https://api.bitbucket.org/2.0/repositories/xnatx/ml-schema-plugin/downloads/ml-schema-plugin-1.0.0.jar
   - https://api.bitbucket.org/2.0/repositories/xnatx/datasets-schema-plugin/downloads/datasets-schema-plugin-1.0.0.jar

--- a/roles/xnat_container_service/tasks/main.yml
+++ b/roles/xnat_container_service/tasks/main.yml
@@ -3,6 +3,17 @@
   ansible.builtin.include_tasks: copy_certs_to_client.yml
   when: xnat_container_service_use_ssl
 
+- name: Set service admin user roles
+  ansible.builtin.uri:
+    url:
+      "{{ web_server.url }}/xapi/users/{{ xnat_service_admin.username
+      }}/roles/ContainerManager"
+    user: "{{ xnat_service_admin.username }}"
+    password: "{{ xnat_service_admin.password }}"
+    method: PUT
+    validate_certs: "{{ ssl.validate_certs }}"
+    status_code: 200
+
 - name: Configure XNAT to talk to container service
   ansible.builtin.uri:
     url: "{{ xnat_container_service_url }}"


### PR DESCRIPTION
- update `xnat_version` to 1.9.2.1
- update plugin versions:
  - add a task to assign the `ContainerManager` role to the service admin. In the latest version of the Container Service plugin, site-admins no longer have permissions to manage the Container Service. Instead, all users that manage the plugin must be assigned the `ContainerManager` role.
  - downgrade ldap plugin to 1.1.0 due to issue with plugin always attempting to log in as same user (#162) 