### PR TITLE
Renovate default `tomcat_version`

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -21,8 +21,11 @@
   customManagers: [
     {
       customType: "regex",
-      description: "Update Tomcat version specified in playbooks/group_vars/xnat.yml",
-      managerFilePatterns: ["/(^|/)*xnat.yml$/"],
+      description: "Update Tomcat version",
+      managerFilePatterns: [
+        "/playbooks/group_vars/xnat.yml$/",
+        "/roles/tomcat/defaults/main.yml$/",
+      ],
       matchStrings: ["tomcat_version:\\s?(?<currentValue>.*?)\\n"],
       depNameTemplate: "org.apache.tomcat:tomcat",
       datasourceTemplate: "maven",

--- a/roles/tomcat/defaults/main.yml
+++ b/roles/tomcat/defaults/main.yml
@@ -7,7 +7,7 @@ java_home: /usr/lib/jvm/jre
 java_profile_d: /etc/profile.d
 
 # mirsg.tomcat
-tomcat_version: 9.0.97
+tomcat_version: 9.0.104
 tomcat_owner: tomcat
 tomcat_group: tomcat
 


### PR DESCRIPTION
Fixes #175 

- have renovate update the default `tomcat_version` in the tomcat role (as well as in the `install_xnat` playbook
- update the default `tomcat_version` to be the same as the version we use in the `install_xnat` role