### PR TITLE
fix: install docker-py

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -102,6 +102,11 @@
     state: started
     enabled: true
 
+- name: Install docker-py
+  ansible.builtin.pip:
+    name: docker==7.1.0
+    state: present
+
 - name: Initialize Docker Swarm
   community.docker.docker_swarm:
     state: present

--- a/roles/install_python/tasks/main.yml
+++ b/roles/install_python/tasks/main.yml
@@ -10,6 +10,11 @@
     state: present
   loop: "{{ install_python.system_packages }}"
 
+- name: Remove python3-requests
+  ansible.builtin.package:
+    name: python3-requests
+    state: absent
+
 - name: Update pip
   ansible.builtin.pip:
     name:


### PR DESCRIPTION
Changes:

- Installs `docker-py` in the `docker` role (dependency for `community.docker`)
- Removes `python3-requests` package in the `install_python` role to allow the above to work