### PR TITLE
Ensure crypto collection is v2.x.x in molecule requirements for OMERO on EL8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/UCL-MIRSG/.github
-    rev: v0.213.0
+    rev: v0.208.0
     hooks:
       - id: mirsg-hooks

--- a/meta/omero-el8-requirements.yml
+++ b/meta/omero-el8-requirements.yml
@@ -3,7 +3,8 @@ collections:
   - community.general
   - ansible.posix
   - community.postgresql
-  - community.crypto
+  - name: community.crypto
+    version: ">=2.14.1,<3.0.0"
 
 roles:
   - src: ome.omero_web


### PR DESCRIPTION
Related to #180, #181 and #183 - but also sets the restriction in the molecule requirements for OMERO on EL8 (as it may have Python 3.6 installed)

Also reverts https://github.com/UCL-MIRSG/ansible-collection-infra/commit/8113ff8ae4c57b295ca610ad910199a442151b5c so linting passes (see #188)