### PR TITLE
Revert "Renovate: dependency community.crypto to v3"

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -45,7 +45,7 @@ dependencies:
   "ansible.posix": ">=1.5.4"
   "community.postgresql": ">=3.0.0"
   "community.docker": ">=3.4.8"
-  "community.crypto": ">=3.0.2,<3.1.0"
+  "community.crypto": ">=2.14.1,<3.0.0"
 
 # The URL of the originating SCM repository
 repository: https://github.com/UCL-MIRSG/ansible-collection-infra

--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -5,4 +5,4 @@ collections:
   - community.postgresql
   - community.docker
   - name: community.crypto
-    version: ">=3.0.2,<3.1.0"
+    version: ">=2.14.1,<3.0.0"


### PR DESCRIPTION
Reverts UCL-MIRSG/ansible-collection-infra#193 due to https://github.com/UCL-MIRSG/ansible-collection-infra/issues/180
