### PR TITLE
XNAT OIDC

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -56,6 +56,14 @@
     },
     {
       customType: "regex",
+      description: "Update XNAT openid-auth plugin version specified in roles/xnat/defaults/main.yml",
+      managerFilePatterns: ["/roles/xnat/defaults/main.yml$/"],
+      matchStrings: ["openid-auth-plugin-(?<currentValue>.*?).jar"],
+      depNameTemplate: "xnatx/openid-auth-plugin",
+      datasourceTemplate: "bitbucket-tags",
+    },
+    {
+      customType: "regex",
       description: "Update OHIF Viewer plugin version specified in roles/xnat/defaults/main.yml",
       managerFilePatterns: ["/roles/xnat/defaults/main.yml$/"],
       matchStrings: ["ohif-viewer-(?<currentValue>.*?).jar"],

--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -37,6 +37,29 @@ xnat_ldap_filter: ""
 xnat_ldap_ca_cert: ""
 xnat_ldap_keystore_alias: ""
 
+# OIDC configuration
+xnat_oidc_enabled: false
+xnat_oidc_provider_id: ""
+xnat_oidc_display_name: ""
+xnat_oidc_site_url: ""
+xnat_oidc_pre_established_redir_uri: ""
+xnat_oidc_client_id: ""
+xnat_oidc_client_secret: ""
+xnat_oidc_access_token_uri: ""
+xnat_oidc_user_auth_uri: ""
+xnat_oidc_scopes: ""
+xnat_oidc_login_link: ""
+xnat_oidc_should_filter_email_domains: false
+xnat_oidc_allowed_email_domains: [] # yamllint disable-line rule:brackets
+xnat_oidc_force_user_create: false
+xnat_oidc_user_auto_enabled: false
+xnat_oidc_user_auto_verified: false
+xnat_oidc_pkce_enabled: false
+xnat_oidc_email_property: ""
+xnat_oidc_given_name_property: ""
+xnat_oidc_family_name_property: ""
+xnat_oidc_username_pattern: ""
+
 # Plugins
 xnat_plugin_urls:
   - https://api.bitbucket.org/2.0/repositories/xnatdev/xsync/downloads/xsync-plugin-all-1.8.1.jar

--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -64,6 +64,7 @@ xnat_oidc_username_pattern: ""
 xnat_plugin_urls:
   - https://api.bitbucket.org/2.0/repositories/xnatdev/xsync/downloads/xsync-plugin-all-1.8.1.jar
   - https://api.bitbucket.org/2.0/repositories/xnatx/ldap-auth-plugin/downloads/ldap-auth-plugin-1.1.0.jar
+  - https://bitbucket.org/xnatx/openid-auth-plugin/downloads/openid-auth-plugin-1.3.1-xpl.jar
   - https://www.xnat.org/files/ohif-viewer-xnat-plugin/ohif-viewer-3.7.1-fat.jar
   - https://api.bitbucket.org/2.0/repositories/xnatx/ml-schema-plugin/downloads/ml-schema-plugin-1.0.0.jar
   - https://api.bitbucket.org/2.0/repositories/xnatx/datasets-schema-plugin/downloads/datasets-schema-plugin-1.0.0.jar

--- a/roles/xnat/tasks/main.yml
+++ b/roles/xnat/tasks/main.yml
@@ -43,5 +43,9 @@
   ansible.builtin.include_tasks: ldap.yml
   when: xnat_ldap_enabled
 
+- name: Configure OIDC for XNAT
+  ansible.builtin.include_tasks: oidc.yml
+  when: xnat_oidc_enabled
+
 - name: XNAT site configuration
   ansible.builtin.include_tasks: configure.yml

--- a/roles/xnat/tasks/oidc.yml
+++ b/roles/xnat/tasks/oidc.yml
@@ -1,0 +1,12 @@
+---
+- name: Configure OIDC for XNAT
+  ansible.builtin.template:
+    src: oidc-provider.properties.j2
+    dest:
+      "{{ xnat_config_dir }}/auth/{{ xnat_oidc_provider_id
+      }}_oidc-provider.properties"
+    owner: "{{ xnat.owner }}"
+    group: "{{ xnat.group }}"
+    mode: "0644"
+    force: true
+  notify: Restart tomcat

--- a/roles/xnat/templates/oidc-provider.properties.j2
+++ b/roles/xnat/templates/oidc-provider.properties.j2
@@ -1,0 +1,35 @@
+auth.method=openid
+type=openid
+# Open ID Providers are not visible they are accessed via login links
+auto.enabled=true
+auto.verified=true
+provider.id={{ xnat_oidc_provider_id }}
+# Name displayed in the UI
+name={{ xnat_oidc_display_name }}
+# Site URL - the main domain, needed to build the pre-established URL below.
+siteUrl={{ xnat_oidc_site_url }}
+preEstablishedRedirUri={{ xnat_oidc_pre_established_redir_uri }}
+# {{ xnat_oidc_provider_id }} OpenID
+openid.{{ xnat_oidc_provider_id }}.clientId={{ xnat_oidc_client_id }}
+openid.{{ xnat_oidc_provider_id }}.clientSecret={{ xnat_oidc_client_secret }}
+openid.{{ xnat_oidc_provider_id }}.accessTokenUri={{ xnat_oidc_access_token_uri }}
+openid.{{ xnat_oidc_provider_id }}.userAuthUri={{ xnat_oidc_user_auth_uri }}
+openid.{{ xnat_oidc_provider_id }}.scopes={{ xnat_oidc_scopes }}
+openid.{{ xnat_oidc_provider_id }}.link={{ xnat_oidc_login_link }}
+# Flag that sets if we should be checking email domains
+openid.{{ xnat_oidc_provider_id }}.shouldFilterEmailDomains={{ xnat_oidc_should_filter_email_domains }}
+# Domains below are allowed to login, only checked when 'shouldFilterEmailDomains' is true
+openid.{{ xnat_oidc_provider_id }}.allowedEmailDomains={{ xnat_oidc_allowed_email_domains }}
+# Flag to force the user creation process, normally this should be set to true
+openid.{{ xnat_oidc_provider_id }}.forceUserCreate={{ xnat_oidc_force_user_create }}
+# Flag to set the enabled property of new users, set to false to allow admins to manually enable users before allowing logins, set to true to allow access right away
+openid.{{ xnat_oidc_provider_id }}.userAutoEnabled={{ xnat_oidc_user_auto_enabled }}
+# Flag to set the verified property of new users
+openid.{{ xnat_oidc_provider_id }}.userAutoVerified={{ xnat_oidc_user_auto_verified }}
+# Flag to enable PKCE support, set to true if the OpenID provider supports PKCE
+openid.{{ xnat_oidc_provider_id }}.pkceEnabled={{ xnat_oidc_pkce_enabled }}
+# Property names to use when creating users
+openid.{{ xnat_oidc_provider_id }}.emailProperty={{ xnat_oidc_email_property }}
+openid.{{ xnat_oidc_provider_id }}.givenNameProperty={{ xnat_oidc_given_name_property }}
+openid.{{ xnat_oidc_provider_id }}.familyNameProperty={{ xnat_oidc_family_name_property }}
+openid.{{ xnat_oidc_provider_id }}.usernamePattern={{ xnat_oidc_username_pattern }}


### PR DESCRIPTION
Updated defaults and added basic task to [install and configure the XNAT OIDC Plugin](https://wiki.xnat.org/xnat-tools/openid-authentication-plugin)

As with the LDAP tasks in our XNAT role, no configuration is done in this collection. This must be added as part of a deployment repository