### PR TITLE
Tomcat 9.0.108 and 10.1.44

### DIFF
--- a/playbooks/group_vars/xnat.yml
+++ b/playbooks/group_vars/xnat.yml
@@ -21,7 +21,7 @@ xnat_source:
   context_file_location: /usr/share/tomcat/webapps/ROOT/META-INF/context.xml
 
 # mirsg.infrastructure.tomcat
-tomcat_version: 9.0.107
+tomcat_version: 9.0.108
 tomcat_owner: tomcat
 tomcat_group: tomcat
 

--- a/roles/tomcat/defaults/main.yml
+++ b/roles/tomcat/defaults/main.yml
@@ -7,7 +7,7 @@ java_home: /usr/lib/jvm/jre
 java_profile_d: /etc/profile.d
 
 # mirsg.tomcat
-tomcat_version: 9.0.107
+tomcat_version: 9.0.108
 tomcat_owner: tomcat
 tomcat_group: tomcat
 

--- a/roles/tomcat/molecule/resources/inventory/group_vars/tomcat10.yml
+++ b/roles/tomcat/molecule/resources/inventory/group_vars/tomcat10.yml
@@ -1,2 +1,2 @@
 ---
-tomcat_version: 10.1.43
+tomcat_version: 10.1.44


### PR DESCRIPTION
https://dlcdn.apache.org/ only has the latest versions of Tomcat, so #196 is failing CI as the older versions of the binaries are no longer accessible.