### PR TITLE
Additional settings for restricting local accounts

### DIFF
--- a/roles/xnat/templates/xnat-settings.json.j2
+++ b/roles/xnat/templates/xnat-settings.json.j2
@@ -117,5 +117,8 @@
   "sitewideSeriesImportFilterMode": "blacklist",
   "siteId": "{{ xnat_config.site_name }}",
   "uiAllowNewUserComments": true,
-  "siteHome": "/screens/QuickSearch.vm"
+  "siteHome": "/screens/QuickSearch.vm",
+  "securityNewUserRegistrationDisabled": "{{ xnat_common_config.securityNewUserRegistrationDisabled | default(true) }}",
+  "securityExternalUserParDisabled": "{{ xnat_common_config.securityExternalUserParDisabled | default(false) }}",
+  "securityLocalDbParRegistrationDisabled": "{{ xnat_common_config.securityLocalDbParRegistrationDisabled | default(false) }}"
 }


### PR DESCRIPTION
Adds [additional Settings for Restricting localdb Account Creation](https://wiki.xnat.org/documentation/configuring-authentication-providers#ConfiguringAuthenticationProviders-AdditionalSettingsforRestrictinglocaldbAccountCreation) so that we can enable built in functionality that was removed from https://github.com/UCL-MIRSG/mirsg-xnat-plugin/pull/16

The default behaviour is that:
- Hide (localdb) User Registration Options - TRUE (`securityNewUserRegistrationDisabled`)
- Disable Local DB Project Access Requests - FALSE (`securityExternalUserParDisabled`)
- Disable External Project Access Requests - FALSE (`securityLocalDbParRegistrationDisabled`)

These can be overriden in `xnat_common_config`
