### PR TITLE
Upgrade XNAT to 1.9.3.2

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -13,7 +13,8 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Check links
-        uses: UCL-MIRSG/.github/actions/links@79137691d608fe39cb426c2adf7787768f00d5ee # v0
+        uses: UCL-MIRSG/.github/actions/links@0ebba40bf580f7aed98275c156ab8fb71c33ea82 # v0
         with:
           app-id: ${{ vars.LINKS_APP_ID }}
           app-pem: ${{ secrets.LINKS_PRIVATE_KEY }}
+          lychee-args: --insecure --no-progress --verbose .

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ for an example.
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
 This repo has `pre-commit` hooks enabled, for instructions see
-<https://github.com/UCL-MIRSG/.github/tree/main/precommit>.
+<https://github.com/UCL-MIRSG/.github/tree/main/prek>.
 
 ## License
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -45,7 +45,7 @@ dependencies:
   "ansible.posix": ">=1.5.4"
   "community.postgresql": ">=3.0.0"
   "community.docker": ">=3.4.8"
-  "community.crypto": ">=3.0.5,<3.1.0"
+  "community.crypto": ">=2.14.1,<3.0.0"
 
 # The URL of the originating SCM repository
 repository: https://github.com/UCL-MIRSG/ansible-collection-infra

--- a/meta/el9-requirements.yml
+++ b/meta/el9-requirements.yml
@@ -9,4 +9,4 @@ collections:
   - name: community.docker
     version: 5.0.3
   - name: community.crypto
-    version: ">=3.0.5,<3.1.0"
+    version: ">=2.14.1,<3.0.0"

--- a/molecule_configs/centos7_base_config.yml
+++ b/molecule_configs/centos7_base_config.yml
@@ -12,6 +12,7 @@ driver:
 platforms:
   - name: instance
     hostname: molecule.instance.local
+    arch: x86_64
     image: ${MOLECULE_DOCKER_IMAGE:-geerlingguy/docker-centos7-ansible:latest}
     required: true
     command: ""
@@ -64,3 +65,5 @@ lint: |
   set -e
   yamllint .
   ansible-lint .
+
+prerun: false

--- a/playbooks/group_vars/xnat.yml
+++ b/playbooks/group_vars/xnat.yml
@@ -21,7 +21,7 @@ xnat_source:
   context_file_location: /usr/share/tomcat/webapps/ROOT/META-INF/context.xml
 
 # mirsg.infrastructure.tomcat
-tomcat_version: 9.0.111
+tomcat_version: 9.0.115
 tomcat_owner: tomcat
 tomcat_group: tomcat
 

--- a/roles/postgresql_upgrade/README.md
+++ b/roles/postgresql_upgrade/README.md
@@ -40,11 +40,11 @@ To use this role, add it to the list of roles in a play:
         name: tomcat
         state: stopped
 
-- name: Upgrade Postgresql from version 12 to 14
+- name: Upgrade Postgresql from version 14 to 15
   hosts: db
   vars:
-    postgreql_upgrade_current_version: 12
-    postgreql_upgrade_new_version: 14
+    postgreql_upgrade_current_version: 14
+    postgreql_upgrade_new_version: 15
     postgresql_upgrade_data_dir:
       "/var/lib/pgsql/{{ postgreql_upgrade_new_version }}/data"
     postgresql_upgrade_scripts_dir:

--- a/roles/tomcat/defaults/main.yml
+++ b/roles/tomcat/defaults/main.yml
@@ -7,7 +7,7 @@ java_home: /usr/lib/jvm/jre
 java_profile_d: /etc/profile.d
 
 # mirsg.tomcat
-tomcat_version: 9.0.111
+tomcat_version: 9.0.115
 tomcat_owner: tomcat
 tomcat_group: tomcat
 

--- a/roles/tomcat/molecule/resources/inventory/group_vars/tomcat10.yml
+++ b/roles/tomcat/molecule/resources/inventory/group_vars/tomcat10.yml
@@ -1,2 +1,2 @@
 ---
-tomcat_version: 10.1.49
+tomcat_version: 10.1.52

--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-xnat_version: 1.9.2.1
+xnat_version: 1.9.3.2
 xnat_pipeline_version: 1.8.10
 xnat_archive_dir: "{{ xnat_root_dir }}/archive"
 xnat_prearchive_dir: "{{ xnat_root_dir }}/prearchive"
@@ -77,14 +77,12 @@ xnat_oidc_username_pattern: upn
 # Plugins
 xnat_plugin_urls:
   - https://api.bitbucket.org/2.0/repositories/xnatdev/xsync/downloads/xsync-plugin-all-1.8.1.jar
-  - https://api.bitbucket.org/2.0/repositories/xnatx/ldap-auth-plugin/downloads/ldap-auth-plugin-1.1.0.jar
-  - https://bitbucket.org/xnatx/openid-auth-plugin/downloads/openid-auth-plugin-1.3.1-xpl.jar
-  - https://www.xnat.org/files/ohif-viewer-xnat-plugin/ohif-viewer-3.7.1-fat.jar
-  - https://api.bitbucket.org/2.0/repositories/xnatx/ml-schema-plugin/downloads/ml-schema-plugin-1.0.0.jar
-  - https://api.bitbucket.org/2.0/repositories/xnatx/datasets-schema-plugin/downloads/datasets-schema-plugin-1.0.0.jar
+  - https://api.bitbucket.org/2.0/repositories/xnatx/ldap-auth-plugin/downloads/ldap-auth-plugin-1.3.0.jar
+  - https://bitbucket.org/xnatx/openid-auth-plugin/downloads/openid-auth-plugin-1.4.1-xpl.jar
+  - https://www.xnat.org/files/ohif-viewer-xnat-plugin/ohif-viewer-3.7.2.jar
   - https://api.bitbucket.org/2.0/repositories/xnatdev/xnat-image-viewer-plugin/downloads/ximgview-plugin-1.0.2.jar
   - https://api.bitbucket.org/2.0/repositories/xnatx/xnatx-dxm-settings-plugin/downloads/dxm-settings-plugin-1.0.jar
-  - https://api.bitbucket.org/2.0/repositories/xnatx/pipeline_engine_plugin/downloads/pipeline_engine_ui-1.1.0-xpl.jar
+  - https://api.bitbucket.org/2.0/repositories/xnatx/pipeline_engine_plugin/downloads/pipeline_engine_ui-1.2.0-xpl.jar
 
 xnat_plugin_bundle_urls: [] # yamllint disable-line rule:brackets
 xnat_plugin_packages: [] # yamllint disable-line rule:brackets

--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -97,3 +97,7 @@ xnat_pipeline_engine_enabled: true
 
 # Note that AutoRun is currently required for session archive notifications
 xnat_autorun_enabled: false
+
+# Automation Service  - https://radiologics.atlassian.net/browse/XNAT-3822
+# Defaults to true as that's the current configuration
+xnat_automation_enabled: true

--- a/roles/xnat/templates/xnat-conf.properties.j2
+++ b/roles/xnat/templates/xnat-conf.properties.j2
@@ -12,3 +12,4 @@ hibernate.hbm2ddl.auto=update
 hibernate.show_sql=false
 hibernate.cache.use_second_level_cache=true
 hibernate.cache.use_query_cache=true
+automation.enabled={{ xnat_automation_enabled }}

--- a/roles/xnat/templates/xnat-conf.properties.j2
+++ b/roles/xnat/templates/xnat-conf.properties.j2
@@ -12,4 +12,4 @@ hibernate.hbm2ddl.auto=update
 hibernate.show_sql=false
 hibernate.cache.use_second_level_cache=true
 hibernate.cache.use_query_cache=true
-automation.enabled={{ xnat_automation_enabled }}
+automation.enabled={{ xnat_automation_enabled | lower }}


### PR DESCRIPTION
This PR:
1. Updates XNAT version to 1.9.3.2
2. Updates default plugins to match including fixes #162 
3. Updates Tomcat to latest version
4. Enables a flag to toggle the automation service
5. Reverts ansible.community.crypto version back to one that supports Python 2.7 and Python <3.6

I can't figure out why the postgres tests are failing, but it's an unrelated issue to the changes here, and deploying https://github.com/UCL-MIRSG/UCLMedicalImagingEnv/pull/516 to ucl-test-xnat (https://github.com/UCL-MIRSG/UCLMedicalImagingEnv/actions/runs/22901520908) works 