### PR TITLE
Remove oidc plugin from default

### DIFF
--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -78,7 +78,6 @@ xnat_oidc_username_pattern: upn
 xnat_plugin_urls:
   - https://api.bitbucket.org/2.0/repositories/xnatdev/xsync/downloads/xsync-plugin-all-1.8.1.jar
   - https://api.bitbucket.org/2.0/repositories/xnatx/ldap-auth-plugin/downloads/ldap-auth-plugin-1.3.0.jar
-  - https://bitbucket.org/xnatx/openid-auth-plugin/downloads/openid-auth-plugin-1.4.1-xpl.jar
   - https://www.xnat.org/files/ohif-viewer-xnat-plugin/ohif-viewer-3.7.2.jar
   - https://api.bitbucket.org/2.0/repositories/xnatdev/xnat-image-viewer-plugin/downloads/ximgview-plugin-1.0.2.jar
   - https://api.bitbucket.org/2.0/repositories/xnatx/xnatx-dxm-settings-plugin/downloads/dxm-settings-plugin-1.0.jar


### PR DESCRIPTION
The latest version of OIDC plugin seems to cause issues when installed but not configured, so I'm removing from default