### PR TITLE
Update XNAT version to 1.9.3.5

### DIFF
--- a/playbooks/group_vars/xnat.yml
+++ b/playbooks/group_vars/xnat.yml
@@ -21,7 +21,7 @@ xnat_source:
   context_file_location: /usr/share/tomcat/webapps/ROOT/META-INF/context.xml
 
 # mirsg.infrastructure.tomcat
-tomcat_version: 9.0.118
+tomcat_version: 9.0.119
 tomcat_owner: tomcat
 tomcat_group: tomcat
 

--- a/playbooks/molecule/resources/xnat/inventory/group_vars/all/server.yml
+++ b/playbooks/molecule/resources/xnat/inventory/group_vars/all/server.yml
@@ -38,6 +38,6 @@ xnat_config:
   admin_password: "{{ vault_admin_password }}"
 
 xnat_server_specific_plugin_urls:
-  - https://api.bitbucket.org/2.0/repositories/xnatdev/container-service/downloads/container-service-3.7.1-fat.jar
+  - https://api.bitbucket.org/2.0/repositories/xnatdev/container-service/downloads/container-service-3.8.1-fat.jar
   - https://api.bitbucket.org/2.0/repositories/xnatx/xnatx-batch-launch-plugin/downloads/batch-launch-0.8.0-xpl.jar
   - https://github.com/VUIIS/dax/raw/main/misc/xnat-plugins/dax-plugin-genProcData-1.4.2.jar

--- a/roles/tomcat/defaults/main.yml
+++ b/roles/tomcat/defaults/main.yml
@@ -7,7 +7,7 @@ java_home: /usr/lib/jvm/jre
 java_profile_d: /etc/profile.d
 
 # mirsg.tomcat
-tomcat_version: 9.0.118
+tomcat_version: 9.0.119
 tomcat_owner: tomcat
 tomcat_group: tomcat
 

--- a/roles/xnat/defaults/main.yml
+++ b/roles/xnat/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-xnat_version: 1.9.3.2
+xnat_version: 1.9.3.5
 xnat_pipeline_version: 1.8.10
 xnat_archive_dir: "{{ xnat_root_dir }}/archive"
 xnat_prearchive_dir: "{{ xnat_root_dir }}/prearchive"


### PR DESCRIPTION
This pull request updates the default XNAT version used in the configuration.

- Configuration update:
  * Updated the `xnat_version` variable in `roles/xnat/defaults/main.yml` from `1.9.3.2` to `1.9.3.5`, ensuring deployments use the latest patch version.

Relevant release notes since last update (1.9.3.2)
- https://wiki.xnat.org/documentation/xnat-1-9-3-3-release-notes
- https://wiki.xnat.org/documentation/xnat-1-9-3-4-release-notes
- https://wiki.xnat.org/documentation/xnat-1-9-3-5-release-notes

Only relevant plugin to [update is the Container Service to 3.8.1](https://bitbucket.org/xnatdev/container-service/src/3.8.1/CHANGELOG.md)