### PR TITLE
Add Slack as Alertmanager receiver

### DIFF
--- a/roles/monitoring_server/defaults/main.yml
+++ b/roles/monitoring_server/defaults/main.yml
@@ -38,6 +38,10 @@ monitoring_server_smtp_password: ""
 monitoring_server_smtp_start_tls: false
 ssl_trust: "*"
 
+monitoring_server_slack_enabled: false
+monitoring_server_slack_webhook_url: ""
+monitoring_server_slack_channel: ""
+
 monitoring_server_hostname_extractor: ansible_host
 
 monitoring_server_alertmanager:

--- a/roles/monitoring_server/templates/alertmanager.yml.j2
+++ b/roles/monitoring_server/templates/alertmanager.yml.j2
@@ -1,10 +1,12 @@
 global:
+{% if monitoring_server_smtp_enabled %}
   # The smarthost and SMTP sender used for mail notifications.
   smtp_smarthost: {{ monitoring_server_smtp_hostname }}:{{ monitoring_server_smtp_port }}
   smtp_from: {{ monitoring_server_admin_email }}
   smtp_auth_username: {{ monitoring_server_smtp_username }}
   smtp_auth_password: {{ monitoring_server_smtp_password }}
   smtp_require_tls: {{ monitoring_server_smtp_start_tls }}
+{% endif %}
 
 # The directory from which notification templates are read.
 templates:
@@ -30,10 +32,31 @@ route:
   # resend them.
   repeat_interval: 2h
 
-  # A default receiver
-  receiver: mirsg-admin-email
+  # A default null receiver; active receivers are configured as child routes
+  receiver: null
+  routes:
+{% if monitoring_server_smtp_enabled %}
+    - receiver: mirsg-admin-email
+      continue: true
+{% endif %}
+{% if monitoring_server_slack_enabled %}
+    - receiver: mirsg-slack
+      continue: true
+{% endif %}
 
 receivers:
+  - name: 'null'
+{% if monitoring_server_smtp_enabled %}
   - name: 'mirsg-admin-email'
     email_configs:
-    - to: {{ monitoring_server_notification_email }}
+      - to: {{ monitoring_server_notification_email }}
+{% endif %}
+{% if monitoring_server_slack_enabled %}
+  - name: 'mirsg-slack'
+    slack_configs:
+      - api_url: {{ monitoring_server_slack_webhook_url }}
+        channel: {{ monitoring_server_slack_channel }}
+        # Note: when using an incoming webhook, the target channel is set in Slack
+        # when the webhook is created. This field is required by the schema but
+        # does not override the webhook's channel.
+{% endif %}

--- a/roles/monitoring_server/templates/alertmanager.yml.j2
+++ b/roles/monitoring_server/templates/alertmanager.yml.j2
@@ -33,7 +33,8 @@ route:
   repeat_interval: 2h
 
   # A default null receiver; active receivers are configured as child routes
-  receiver: null
+  receiver: 'null'
+{% if monitoring_server_smtp_enabled or monitoring_server_slack_enabled %}
   routes:
 {% if monitoring_server_smtp_enabled %}
     - receiver: mirsg-admin-email
@@ -42,6 +43,7 @@ route:
 {% if monitoring_server_slack_enabled %}
     - receiver: mirsg-slack
       continue: true
+{% endif %}
 {% endif %}
 
 receivers:
@@ -54,8 +56,8 @@ receivers:
 {% if monitoring_server_slack_enabled %}
   - name: 'mirsg-slack'
     slack_configs:
-      - api_url: {{ monitoring_server_slack_webhook_url }}
-        channel: {{ monitoring_server_slack_channel }}
+      - api_url: "{{ monitoring_server_slack_webhook_url }}"
+        channel: "{{ monitoring_server_slack_channel }}"
         # Note: when using an incoming webhook, the target channel is set in Slack
         # when the webhook is created. This field is required by the schema but
         # does not override the webhook's channel.


### PR DESCRIPTION
This pull request adds basic support for sending monitoring alerts to Slack in addition to email. As it stands, no configuration of Slack messages is possible.

**Slack integration:**

* Added new variables to `main.yml` for enabling Slack notifications and specifying the Slack webhook URL and channel.
* Updated the Alertmanager template to optionally add a Slack receiver and route when Slack notifications are enabled.

**Alertmanager configuration improvements:**

* Modified the default receiver to be a null receiver, and conditionally added child routes for email and Slack receivers based on their enabled status.
* Made all SMTP (email) configuration in the Alertmanager template conditional on the SMTP notification feature being enabled.