### PR TITLE
GHA workflows to v0.252.0

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Check links
-        uses: UCL-MIRSG/.github/actions/links@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
+        uses: UCL-MIRSG/.github/actions/links@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0
         with:
           app-id: ${{ vars.LINKS_APP_ID }}
           app-pem: ${{ secrets.LINKS_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]

--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Check links
-        uses: UCL-MIRSG/.github/actions/links@0ebba40bf580f7aed98275c156ab8fb71c33ea82 # v0
+        uses: UCL-MIRSG/.github/actions/links@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
         with:
           app-id: ${{ vars.LINKS_APP_ID }}
           app-pem: ${{ secrets.LINKS_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]

--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Check links
-        uses: UCL-MIRSG/.github/actions/links@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
+        uses: UCL-MIRSG/.github/actions/links@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
         with:
           app-id: ${{ vars.LINKS_APP_ID }}
           app-pem: ${{ secrets.LINKS_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -34,6 +34,6 @@ jobs:
         run: |-
           ansible-galaxy install -r ./meta/omero-el9-requirements.yml
 
-      - uses: UCL-MIRSG/.github/actions/linting@da2eaa5334ee42fbf605f3962598284e1bed59b2 # v0
+      - uses: UCL-MIRSG/.github/actions/linting@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
         with:
           pre-commit-config: ./.pre-commit-config.yaml

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -34,6 +34,6 @@ jobs:
         run: |-
           ansible-galaxy install -r ./meta/omero-el9-requirements.yml
 
-      - uses: UCL-MIRSG/.github/actions/linting@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
+      - uses: UCL-MIRSG/.github/actions/linting@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0
         with:
           pre-commit-config: ./.pre-commit-config.yaml

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -34,6 +34,6 @@ jobs:
         run: |-
           ansible-galaxy install -r ./meta/omero-el9-requirements.yml
 
-      - uses: UCL-MIRSG/.github/actions/linting@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
+      - uses: UCL-MIRSG/.github/actions/linting@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
         with:
           pre-commit-config: ./.pre-commit-config.yaml

--- a/.github/workflows/manage-projects.yaml
+++ b/.github/workflows/manage-projects.yaml
@@ -11,7 +11,7 @@ jobs:
     permissions: {}
     runs-on: ubuntu-latest
     steps:
-      - uses: UCL-MIRSG/.github/actions/add-to-project@e16932bcb9189707188ea268d4605e042c2b5d9a # v0
+      - uses: UCL-MIRSG/.github/actions/add-to-project@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
         with:
           app-id: ${{ secrets.APP_ID }} # zizmor: ignore[secrets-outside-env]
           app-pem: ${{ secrets.APP_PEM }} # zizmor: ignore[secrets-outside-env]

--- a/.github/workflows/manage-projects.yaml
+++ b/.github/workflows/manage-projects.yaml
@@ -11,7 +11,7 @@ jobs:
     permissions: {}
     runs-on: ubuntu-latest
     steps:
-      - uses: UCL-MIRSG/.github/actions/add-to-project@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
+      - uses: UCL-MIRSG/.github/actions/add-to-project@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0
         with:
           app-id: ${{ secrets.APP_ID }} # zizmor: ignore[secrets-outside-env]
           app-pem: ${{ secrets.APP_PEM }} # zizmor: ignore[secrets-outside-env]

--- a/.github/workflows/manage-projects.yaml
+++ b/.github/workflows/manage-projects.yaml
@@ -11,7 +11,7 @@ jobs:
     permissions: {}
     runs-on: ubuntu-latest
     steps:
-      - uses: UCL-MIRSG/.github/actions/add-to-project@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
+      - uses: UCL-MIRSG/.github/actions/add-to-project@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
         with:
           app-id: ${{ secrets.APP_ID }} # zizmor: ignore[secrets-outside-env]
           app-pem: ${{ secrets.APP_PEM }} # zizmor: ignore[secrets-outside-env]

--- a/.github/workflows/molecule-docker.yaml
+++ b/.github/workflows/molecule-docker.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e16932bcb9189707188ea268d4605e042c2b5d9a # v0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-docker.yaml
+++ b/.github/workflows/molecule-docker.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-docker.yaml
+++ b/.github/workflows/molecule-docker.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-firewalld.yaml
+++ b/.github/workflows/molecule-firewalld.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e16932bcb9189707188ea268d4605e042c2b5d9a # v0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-firewalld.yaml
+++ b/.github/workflows/molecule-firewalld.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-firewalld.yaml
+++ b/.github/workflows/molecule-firewalld.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-install-omero.yaml
+++ b/.github/workflows/molecule-install-omero.yaml
@@ -45,7 +45,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
         env:
           ROCKY_VERSION: ${{ matrix.rocky_version }}
         with:

--- a/.github/workflows/molecule-install-omero.yaml
+++ b/.github/workflows/molecule-install-omero.yaml
@@ -45,7 +45,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0
         env:
           ROCKY_VERSION: ${{ matrix.rocky_version }}
         with:

--- a/.github/workflows/molecule-install-omero.yaml
+++ b/.github/workflows/molecule-install-omero.yaml
@@ -45,7 +45,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e16932bcb9189707188ea268d4605e042c2b5d9a # v0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
         env:
           ROCKY_VERSION: ${{ matrix.rocky_version }}
         with:

--- a/.github/workflows/molecule-install-xnat.yaml
+++ b/.github/workflows/molecule-install-xnat.yaml
@@ -47,7 +47,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-install-xnat.yaml
+++ b/.github/workflows/molecule-install-xnat.yaml
@@ -47,7 +47,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e16932bcb9189707188ea268d4605e042c2b5d9a # v0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-install-xnat.yaml
+++ b/.github/workflows/molecule-install-xnat.yaml
@@ -47,7 +47,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-java.yaml
+++ b/.github/workflows/molecule-java.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e16932bcb9189707188ea268d4605e042c2b5d9a # v0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-java.yaml
+++ b/.github/workflows/molecule-java.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-java.yaml
+++ b/.github/workflows/molecule-java.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-ldap.yaml
+++ b/.github/workflows/molecule-ldap.yaml
@@ -43,7 +43,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-ldap.yaml
+++ b/.github/workflows/molecule-ldap.yaml
@@ -43,7 +43,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e16932bcb9189707188ea268d4605e042c2b5d9a # v0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-ldap.yaml
+++ b/.github/workflows/molecule-ldap.yaml
@@ -43,7 +43,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-monitoring.yaml
+++ b/.github/workflows/molecule-monitoring.yaml
@@ -45,7 +45,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-monitoring.yaml
+++ b/.github/workflows/molecule-monitoring.yaml
@@ -45,7 +45,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e16932bcb9189707188ea268d4605e042c2b5d9a # v0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-monitoring.yaml
+++ b/.github/workflows/molecule-monitoring.yaml
@@ -45,7 +45,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-nginx.yaml
+++ b/.github/workflows/molecule-nginx.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e16932bcb9189707188ea268d4605e042c2b5d9a # v0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-nginx.yaml
+++ b/.github/workflows/molecule-nginx.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-nginx.yaml
+++ b/.github/workflows/molecule-nginx.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-postgresql.yaml
+++ b/.github/workflows/molecule-postgresql.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e16932bcb9189707188ea268d4605e042c2b5d9a # v0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-postgresql.yaml
+++ b/.github/workflows/molecule-postgresql.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-postgresql.yaml
+++ b/.github/workflows/molecule-postgresql.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-postgresql_upgrade.yaml
+++ b/.github/workflows/molecule-postgresql_upgrade.yaml
@@ -43,7 +43,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-postgresql_upgrade.yaml
+++ b/.github/workflows/molecule-postgresql_upgrade.yaml
@@ -43,7 +43,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e16932bcb9189707188ea268d4605e042c2b5d9a # v0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-postgresql_upgrade.yaml
+++ b/.github/workflows/molecule-postgresql_upgrade.yaml
@@ -43,7 +43,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-provision.yaml
+++ b/.github/workflows/molecule-provision.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e16932bcb9189707188ea268d4605e042c2b5d9a # v0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-provision.yaml
+++ b/.github/workflows/molecule-provision.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-provision.yaml
+++ b/.github/workflows/molecule-provision.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-provision_accounts.yaml
+++ b/.github/workflows/molecule-provision_accounts.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e16932bcb9189707188ea268d4605e042c2b5d9a # v0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-provision_accounts.yaml
+++ b/.github/workflows/molecule-provision_accounts.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-provision_accounts.yaml
+++ b/.github/workflows/molecule-provision_accounts.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-python.yaml
+++ b/.github/workflows/molecule-python.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e16932bcb9189707188ea268d4605e042c2b5d9a # v0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-python.yaml
+++ b/.github/workflows/molecule-python.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-python.yaml
+++ b/.github/workflows/molecule-python.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-tomcat.yaml
+++ b/.github/workflows/molecule-tomcat.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e16932bcb9189707188ea268d4605e042c2b5d9a # v0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-tomcat.yaml
+++ b/.github/workflows/molecule-tomcat.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@e4daf6da08d7b05e7442512fb07ae4c7d9bc1e99 # v0.250.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.github/workflows/molecule-tomcat.yaml
+++ b/.github/workflows/molecule-tomcat.yaml
@@ -44,7 +44,7 @@ jobs:
             /etc/apparmor.d/unix-chkpwd
           sudo apparmor_parser -r /etc/apparmor.d/unix-chkpwd
 
-      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0.252.0
+      - uses: UCL-MIRSG/.github/actions/molecule-test@f0317ea26124fe0b3b923d881ac956301a11ea56 # v0
         with:
           ansible_major_version: ${{ vars.ANSIBLE_MAJOR_VERSION }}
           scenario: ${{ matrix.scenario }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/UCL-MIRSG/.github
-    rev: v0.250.0
+    rev: v0.252.0
     hooks:
       - id: mirsg-hooks

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -77,7 +77,7 @@ on:
 
 jobs:
   molecule-my_playbook:
-    uses: UCL-MIRSG/.github/actions/molecule-test@v0
+    uses: UCL-MIRSG/.github/actions/molecule-test@v0.250.0
     with:
       tests-path: ansible_collections/mirsg/infrastructure/playbooks
 ```

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -77,7 +77,7 @@ on:
 
 jobs:
   molecule-my_playbook:
-    uses: UCL-MIRSG/.github/actions/molecule-test@v0.250.0
+    uses: UCL-MIRSG/.github/actions/molecule-test@v0
     with:
       tests-path: ansible_collections/mirsg/infrastructure/playbooks
 ```

--- a/roles/README.md
+++ b/roles/README.md
@@ -86,7 +86,7 @@ on:
 
 jobs:
   molecule-my_role:
-    uses: UCL-MIRSG/.github/actions/molecule-test@v0.250.0
+    uses: UCL-MIRSG/.github/actions/molecule-test@v0
     with:
       tests-path: ansible_collections/mirsg/infrastructure/roles/my_role
 ```

--- a/roles/README.md
+++ b/roles/README.md
@@ -86,7 +86,7 @@ on:
 
 jobs:
   molecule-my_role:
-    uses: UCL-MIRSG/.github/actions/molecule-test@v0
+    uses: UCL-MIRSG/.github/actions/molecule-test@v0.250.0
     with:
       tests-path: ansible_collections/mirsg/infrastructure/roles/my_role
 ```

--- a/roles/firewalld/molecule/centos7/molecule.yml
+++ b/roles/firewalld/molecule/centos7/molecule.yml
@@ -1,3 +1,4 @@
 ---
 # test this scenario from the roles/firewalld directory with the command
 # molecule --base-config ../../molecule_configs/centos7_base_config.yml test --scenario centos7
+{}

--- a/roles/firewalld/molecule/rocky9/molecule.yml
+++ b/roles/firewalld/molecule/rocky9/molecule.yml
@@ -1,3 +1,4 @@
 ---
 # test this scenario from the roles/firewalld directory with the command
 # molecule --base-config ../../molecule_configs/rocky9_base_config.yml test --scenario rocky9
+{}

--- a/roles/install_java/molecule/centos7/molecule.yml
+++ b/roles/install_java/molecule/centos7/molecule.yml
@@ -1,3 +1,4 @@
 ---
 # test this scenario from the roles/install_java directory with the command
 # molecule --base-config ../../molecule_configs/centos7_base_config.yml test --scenario centos7
+{}

--- a/roles/install_java/molecule/rocky9/molecule.yml
+++ b/roles/install_java/molecule/rocky9/molecule.yml
@@ -1,3 +1,4 @@
 ---
 # test this scenario from the roles/install_java directory with the command
 # molecule --base-config ../../molecule_configs/rocky9_base_config.yml test --scenario rocky9
+{}

--- a/roles/install_python/molecule/centos7/molecule.yml
+++ b/roles/install_python/molecule/centos7/molecule.yml
@@ -1,3 +1,4 @@
 ---
 # test this scenario from the roles/install_python directory with the command
 # molecule --base-config ../../molecule_configs/centos7_base_config.yml test --scenario centos7
+{}

--- a/roles/install_python/molecule/rocky9/molecule.yml
+++ b/roles/install_python/molecule/rocky9/molecule.yml
@@ -1,3 +1,4 @@
 ---
 # test this scenario from the roles/install_python directory with the command
 # molecule --base-config ../../molecule_configs/rocky9_base_config.yml test --scenario rocky9
+{}

--- a/roles/postgresql/molecule/centos7/molecule.yml
+++ b/roles/postgresql/molecule/centos7/molecule.yml
@@ -2,3 +2,4 @@
 # test this scenario from the roles/postgresql directory with the command
 # molecule --base-config ../../molecule_configs/centos7_base_config.yml
 # test --scenario centos7
+{}

--- a/roles/postgresql/molecule/rocky9/molecule.yml
+++ b/roles/postgresql/molecule/rocky9/molecule.yml
@@ -1,3 +1,4 @@
 ---
 # test this scenario from the roles/postgresql directory with the command
 # molecule --base-config ../../molecule_configs/rocky9_base_config.yml test --scenario rocky9
+{}

--- a/roles/postgresql_upgrade/molecule/centos7/molecule.yml
+++ b/roles/postgresql_upgrade/molecule/centos7/molecule.yml
@@ -1,3 +1,4 @@
 ---
 # test this scenario from the roles/provision_accounts directory with the command
 # molecule --base-config ../../molecule_configs/centos7_base_config.yml test --scenario centos7
+{}

--- a/roles/postgresql_upgrade/molecule/rocky9/molecule.yml
+++ b/roles/postgresql_upgrade/molecule/rocky9/molecule.yml
@@ -1,3 +1,4 @@
 ---
 # test this scenario from the roles/provision_accounts directory with the command
 # molecule --base-config ../../molecule_configs/rocky9_base_config.yml test --scenario rocky9
+{}

--- a/roles/provision/molecule/centos7/molecule.yml
+++ b/roles/provision/molecule/centos7/molecule.yml
@@ -1,3 +1,4 @@
 ---
 # test this scenario from the roles/provision directory with the command
 # molecule --base-config ../../molecule_configs/centos7_base_config.yml test --scenario centos7
+{}

--- a/roles/provision/molecule/rocky9/molecule.yml
+++ b/roles/provision/molecule/rocky9/molecule.yml
@@ -1,3 +1,4 @@
 ---
 # test this scenario from the roles/provision directory with the command
 # molecule --base-config ../../molecule_configs/rocky9_base_config.yml test --scenario rocky9
+{}

--- a/roles/provision_accounts/molecule/centos7/molecule.yml
+++ b/roles/provision_accounts/molecule/centos7/molecule.yml
@@ -1,3 +1,4 @@
 ---
 # test this scenario from the roles/provision_accounts directory with the command
 # molecule --base-config ../../molecule_configs/centos7_base_config.yml test --scenario centos7
+{}

--- a/roles/provision_accounts/molecule/rocky9/molecule.yml
+++ b/roles/provision_accounts/molecule/rocky9/molecule.yml
@@ -1,3 +1,4 @@
 ---
 # test this scenario from the roles/provision_accounts directory with the command
 # molecule --base-config ../../molecule_configs/rocky9_base_config.yml test --scenario rocky9
+{}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows and documentation to use the latest version (`v0.252.0`) of the shared actions from the `UCL-MIRSG/.github` repository. I noticed a lot of the workflows were pointing at older commits and so using actions that used a deprecated version of Node.