### PR TITLE
Fix ansible molecule validation errors

### DIFF
--- a/molecule_configs/centos7_base_config.yml
+++ b/molecule_configs/centos7_base_config.yml
@@ -12,9 +12,7 @@ driver:
 platforms:
   - name: instance
     hostname: molecule.instance.local
-    arch: x86_64
     image: ${MOLECULE_DOCKER_IMAGE:-geerlingguy/docker-centos7-ansible:latest}
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true

--- a/molecule_configs/rocky9_base_config.yml
+++ b/molecule_configs/rocky9_base_config.yml
@@ -13,7 +13,6 @@ platforms:
   - name: instance
     hostname: molecule.instance.local
     image: rockylinux/rockylinux:9-ubi-init
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true

--- a/playbooks/molecule/centos7_monitoring/molecule.yml
+++ b/playbooks/molecule/centos7_monitoring/molecule.yml
@@ -13,7 +13,6 @@ platforms:
   - name: mclient
     hostname: molecule.mclient.local
     image: ${MOLECULE_DOCKER_IMAGE:-geerlingguy/docker-centos7-ansible:latest}
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true
@@ -40,7 +39,6 @@ platforms:
   - name: mserv
     hostname: molecule.mserv.local
     image: ${MOLECULE_DOCKER_IMAGE:-geerlingguy/docker-centos7-ansible:latest}
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true
@@ -57,8 +55,8 @@ platforms:
       - name: monitoring
         ipv4_address: 192.168.56.3
     exposed_ports:
-      - 80
-      - 443
+      - "80"
+      - "443"
     etc_hosts:
       molecule.mclient.local: 192.168.56.2
 

--- a/playbooks/molecule/centos7_xnat/molecule.yml
+++ b/playbooks/molecule/centos7_xnat/molecule.yml
@@ -13,8 +13,7 @@ platforms:
   - name: xnat_db
     hostname: xnat.db.local
     image: geerlingguy/docker-centos7-ansible:latest
-    required: true
-    command:
+    command: ""
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
@@ -35,7 +34,7 @@ platforms:
       - name: xnat
         ipv4_address: 192.168.56.2
     exposed_ports:
-      - 5432
+      - "5432"
     etc_hosts:
       xnat.web.local: 192.168.56.3
       xnat.cserv.local: 192.168.56.4
@@ -43,8 +42,7 @@ platforms:
   - name: xnat_web
     hostname: xnat.web.local
     image: geerlingguy/docker-centos7-ansible:latest
-    required: true
-    command:
+    command: ""
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
@@ -62,10 +60,10 @@ platforms:
       - name: xnat
         ipv4_address: 192.168.56.3
     exposed_ports:
-      - 80
-      - 443
-      - 8080
-      - 8104
+      - "80"
+      - "443"
+      - "8080"
+      - "8104"
     published_ports:
       - 127.0.0.1:8080:80
     etc_hosts:
@@ -75,8 +73,7 @@ platforms:
   - name: xnat_cserv
     hostname: xnat.cserv.local
     image: geerlingguy/docker-centos7-ansible:latest
-    required: true
-    command:
+    command: ""
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
@@ -93,8 +90,8 @@ platforms:
       - name: xnat
         ipv4_address: 192.168.56.4
     exposed_ports:
-      - 2376
-    extra_hosts:
+      - "2376"
+    etc_hosts:
       xnat.db.local: 192.168.56.2
       xnat.web.local: 192.168.56.3
 

--- a/playbooks/molecule/rocky9_monitoring/molecule.yml
+++ b/playbooks/molecule/rocky9_monitoring/molecule.yml
@@ -13,7 +13,6 @@ platforms:
   - name: mclient
     hostname: molecule.mclient.local
     image: rockylinux/rockylinux:9-ubi-init
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true
@@ -41,7 +40,6 @@ platforms:
   - name: mserv
     hostname: molecule.mserv.local
     image: rockylinux/rockylinux:9-ubi-init
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true
@@ -59,8 +57,8 @@ platforms:
       - name: monitoring
         ipv4_address: 192.168.56.3
     exposed_ports:
-      - 80
-      - 443
+      - "80"
+      - "443"
     etc_hosts:
       molecule.mclient.local: 192.168.56.2
 

--- a/playbooks/molecule/rocky9_xnat/molecule.yml
+++ b/playbooks/molecule/rocky9_xnat/molecule.yml
@@ -13,7 +13,6 @@ platforms:
   - name: xnat_db
     hostname: xnat.db.local
     image: rockylinux/rockylinux:9-ubi-init
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true
@@ -36,7 +35,7 @@ platforms:
       - name: xnat
         ipv4_address: 192.168.56.2
     exposed_ports:
-      - 5432
+      - "5432"
     etc_hosts:
       xnat.web.local: 192.168.56.3
       xnat.cserv.local: 192.168.56.4
@@ -44,7 +43,6 @@ platforms:
   - name: xnat_web
     hostname: xnat.web.local
     image: rockylinux/rockylinux:9-ubi-init
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true
@@ -64,10 +62,10 @@ platforms:
       - name: xnat
         ipv4_address: 192.168.56.3
     exposed_ports:
-      - 80
-      - 443
-      - 8080
-      - 8104
+      - "80"
+      - "443"
+      - "8080"
+      - "8104"
     published_ports:
       - 127.0.0.1:8080:80
     etc_hosts:
@@ -77,7 +75,6 @@ platforms:
   - name: xnat_cserv
     hostname: xnat.cserv.local
     image: rockylinux/rockylinux:9-ubi-init
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true
@@ -96,8 +93,8 @@ platforms:
       - name: xnat
         ipv4_address: 192.168.56.4
     exposed_ports:
-      - 2376
-    extra_hosts:
+      - "2376"
+    etc_hosts:
       xnat.db.local: 192.168.56.2
       xnat.web.local: 192.168.56.3
 

--- a/playbooks/molecule/rocky_omero/molecule.yml
+++ b/playbooks/molecule/rocky_omero/molecule.yml
@@ -13,7 +13,6 @@ platforms:
   - name: omero_db
     hostname: omero.db.local
     image: rockylinux/rockylinux:${ROCKY_VERSION:-8}-ubi-init
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true
@@ -35,7 +34,7 @@ platforms:
       - name: omero
         ipv4_address: 192.168.56.2
     exposed_ports:
-      - 5432
+      - "5432"
     etc_hosts:
       omero.server.local: 192.168.56.3
       omero.mail.local: 192.168.56.4
@@ -43,8 +42,7 @@ platforms:
   - name: omero_server_web
     hostname: omero.server.local
     image: rockylinux/rockylinux:${ROCKY_VERSION:-8}-ubi-init
-    required: true
-    command:
+    command: ""
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
@@ -60,11 +58,11 @@ platforms:
       - name: omero
         ipv4_address: 192.168.56.3
     exposed_ports:
-      - 80
-      - 443
-      - 4063
-      - 4064
-      - 4080
+      - "80"
+      - "443"
+      - "4063"
+      - "4064"
+      - "4080"
     published_ports:
       - 127.0.0.1:8080:80
     etc_hosts:
@@ -74,8 +72,7 @@ platforms:
   - name: omero_mail
     hostname: omero.mail.local
     image: rnwood/smtp4dev
-    required: true
-    command:
+    command: ""
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
@@ -88,7 +85,7 @@ platforms:
       - name: omero
         ipv4_address: 192.168.56.4
     exposed_ports:
-      - 25
+      - "25"
     published_ports:
       - 127.0.0.1:3000:80
       - 127.0.0.1:2525:25

--- a/roles/autofs_cifs/molecule/rocky9/molecule.yml
+++ b/roles/autofs_cifs/molecule/rocky9/molecule.yml
@@ -5,7 +5,6 @@ platforms:
   - name: client
     hostname: molecule.autofs.local
     image: rockylinux/rockylinux:9-ubi-init
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true
@@ -29,7 +28,6 @@ platforms:
   - name: server
     hostname: molecule.samba.local
     image: ghcr.io/dockur/samba:latest
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true
@@ -43,7 +41,7 @@ platforms:
       - name: molecule_docker
         ipv4_address: 192.168.56.3
     exposed_ports:
-      - 2376
+      - "2376"
     etc_hosts:
       molecule.autofs.local: 192.168.56.2
 

--- a/roles/docker/molecule/centos7/molecule.yml
+++ b/roles/docker/molecule/centos7/molecule.yml
@@ -5,7 +5,6 @@ platforms:
   - name: client
     hostname: molecule.docker-client.local
     image: geerlingguy/docker-centos7-ansible:latest
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true
@@ -30,7 +29,6 @@ platforms:
   - name: server
     hostname: molecule.docker-server.local
     image: geerlingguy/docker-centos7-ansible:latest
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true
@@ -45,7 +43,7 @@ platforms:
       - name: molecule_docker
         ipv4_address: 192.168.56.3
     exposed_ports:
-      - 2376
+      - "2376"
     etc_hosts:
       molecule.docker-client.local: 192.168.56.2
 

--- a/roles/docker/molecule/rocky9/molecule.yml
+++ b/roles/docker/molecule/rocky9/molecule.yml
@@ -5,7 +5,6 @@ platforms:
   - name: client
     hostname: molecule.docker-client.local
     image: rockylinux/rockylinux:9-ubi-init
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true
@@ -31,7 +30,6 @@ platforms:
   - name: server
     hostname: molecule.docker-server.local
     image: rockylinux/rockylinux:9-ubi-init
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true
@@ -47,7 +45,7 @@ platforms:
       - name: molecule_docker
         ipv4_address: 192.168.56.3
     exposed_ports:
-      - 2376
+      - "2376"
     etc_hosts:
       molecule.docker-client.local: 192.168.56.2
 

--- a/roles/nginx/molecule/centos7/molecule.yml
+++ b/roles/nginx/molecule/centos7/molecule.yml
@@ -5,7 +5,6 @@ platforms:
   - name: instance
     hostname: molecule.instance.local
     image: ${MOLECULE_DOCKER_IMAGE:-geerlingguy/docker-centos7-ansible:latest}
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true
@@ -26,9 +25,9 @@ platforms:
       - name: molecule
         ipv4_address: 192.168.56.2
     exposed_ports:
-      - 80
-      - 443
-      - 8000
+      - "80"
+      - "443"
+      - "8000"
     published_ports:
       - 127.0.0.1:8080:443
     etc_hosts:

--- a/roles/nginx/molecule/rocky9/molecule.yml
+++ b/roles/nginx/molecule/rocky9/molecule.yml
@@ -5,7 +5,6 @@ platforms:
   - name: instance
     hostname: molecule.instance.local
     image: rockylinux/rockylinux:9-ubi-init
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true
@@ -27,8 +26,8 @@ platforms:
       - name: molecule
         ipv4_address: 192.168.56.2
     exposed_ports:
-      - 80
-      - 443
-      - 8000
+      - "80"
+      - "443"
+      - "8000"
     published_ports:
       - 127.0.0.1:8080:443

--- a/roles/tomcat/molecule/centos7/molecule.yml
+++ b/roles/tomcat/molecule/centos7/molecule.yml
@@ -5,7 +5,6 @@ platforms:
   - name: tomcat9_server
     hostname: molecule.tomcat9.local
     image: ${MOLECULE_DOCKER_IMAGE:-geerlingguy/docker-centos7-ansible:latest}
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true
@@ -30,7 +29,6 @@ platforms:
   - name: tomcat10_server
     hostname: molecule.tomcat10.local
     image: ${MOLECULE_DOCKER_IMAGE:-geerlingguy/docker-centos7-ansible:latest}
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true

--- a/roles/tomcat/molecule/rocky9/molecule.yml
+++ b/roles/tomcat/molecule/rocky9/molecule.yml
@@ -5,7 +5,6 @@ platforms:
   - name: tomcat9_server
     hostname: molecule.tomcat9.local
     image: rockylinux/rockylinux:9-ubi-init
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true
@@ -31,7 +30,6 @@ platforms:
   - name: tomcat10_server
     hostname: molecule.tomcat10.local
     image: rockylinux/rockylinux:9-ubi-init
-    required: true
     command: ""
     cgroupns_mode: host
     privileged: true


### PR DESCRIPTION
Fixes #225 

The latest version of `molecule-plugins` now ships a schema for the Docker driver. Fix various validation errors that schema validation now raises:

- remove unsupported keywords (`required`, `arch`)
- rename `extra_hosts` to `etc_hosts`
- exposed ports must be quoted
- `commands` need a value (even an empty string)