### PR TITLE
Severity based alerts and improved Slack alerting

### DIFF
--- a/roles/monitoring_server/defaults/main.yml
+++ b/roles/monitoring_server/defaults/main.yml
@@ -97,4 +97,4 @@ monitoring_server_prometheus:
   commandline_args:
     config.file: /prometheus/prometheus.yml
     storage.tsdb.path: /prometheus/data
-    web.external-url: /prometheus/
+    web.external-url: https://{{ monitoring_server_hostname }}/prometheus/

--- a/roles/monitoring_server/handlers/main.yml
+++ b/roles/monitoring_server/handlers/main.yml
@@ -17,6 +17,12 @@
     state: started
     restart: true
 
+- name: Restart alertmanager
+  community.docker.docker_container:
+    name: "{{ monitoring_server_alertmanager.container_name }}"
+    state: started
+    restart: true
+
 - name: Restart docker
   ansible.builtin.service:
     name: "{{ docker_service_name }}"

--- a/roles/monitoring_server/tasks/install_alertmanager_container.yml
+++ b/roles/monitoring_server/tasks/install_alertmanager_container.yml
@@ -16,6 +16,30 @@
       "{{ monitoring_server_alertmanager.external_data_dir }}/alertmanager.yml"
     owner: root
     mode: "0644"
+  notify:
+    - Restart alertmanager
+
+- name: Ensure alertmanager template directory exists
+  ansible.builtin.file:
+    path: "{{ monitoring_server_alertmanager.external_data_dir }}/template"
+    owner: "{{ monitoring_server_owner }}"
+    group: "{{ monitoring_server_group }}"
+    state: directory
+    mode: "0755"
+  when: monitoring_server_slack_enabled
+
+- name: Copy alertmanager Slack notification template
+  ansible.builtin.copy:
+    src: templates/slack.tmpl
+    dest:
+      "{{ monitoring_server_alertmanager.external_data_dir
+      }}/template/slack.tmpl"
+    owner: "{{ monitoring_server_owner }}"
+    group: "{{ monitoring_server_group }}"
+    mode: "0644"
+  when: monitoring_server_slack_enabled
+  notify:
+    - Restart alertmanager
 
 - name: Start alertmanager container
   community.docker.docker_container:

--- a/roles/monitoring_server/templates/alertmanager.yml.j2
+++ b/roles/monitoring_server/templates/alertmanager.yml.j2
@@ -61,4 +61,7 @@ receivers:
         # Note: when using an incoming webhook, the target channel is set in Slack
         # when the webhook is created. This field is required by the schema but
         # does not override the webhook's channel.
+        send_resolved: true
+        title: '{% raw %}{{ template "slack.title" . }}{% endraw %}'
+        text: '{% raw %}{{ template "slack.text" . }}{% endraw %}'
 {% endif %}

--- a/roles/monitoring_server/templates/alertmanager.yml.j2
+++ b/roles/monitoring_server/templates/alertmanager.yml.j2
@@ -1,3 +1,24 @@
+{#
+  Reusable notifier configs. Each macro emits a single-item YAML list; call it as
+  `{{ slack_config() | trim | indent(6) }}` under a `slack_configs:`/`email_configs:`
+  key so the list item lands at 6 spaces and its nested keys at 8.
+  Go-template braces (evaluated by Alertmanager, not Jinja) are wrapped in {% raw %}.
+#}
+{%- macro slack_config() %}
+- api_url: "{{ monitoring_server_slack_webhook_url }}"
+  channel: "{{ monitoring_server_slack_channel }}"
+  # Note: when using an incoming webhook, the target channel is set in Slack
+  # when the webhook is created. This field is required by the schema but
+  # does not override the webhook's channel.
+  send_resolved: true
+  color: '{% raw %}{{ if eq .CommonLabels.severity "critical" }}danger{{ else if eq .CommonLabels.severity "warning" }}warning{{ else }}good{{ end }}{% endraw %}'
+  title: '{% raw %}{{ template "slack.title" . }}{% endraw %}'
+  text: '{% raw %}{{ template "slack.text" . }}{% endraw %}'
+{% endmacro %}
+{%- macro email_config() %}
+- to: {{ monitoring_server_notification_email }}
+  send_resolved: true
+{% endmacro -%}
 global:
 {% if monitoring_server_smtp_enabled %}
   # The smarthost and SMTP sender used for mail notifications.
@@ -12,56 +33,89 @@ global:
 templates:
   - '{{ monitoring_server_alertmanager.volume }}/template/*.tmpl'
 
-# The root route on which each incoming alert enters.
+# The root route on which each incoming alert enters. Severity-specific child
+# routes select the channels and reminder cadence; anything unmatched falls
+# through to the 'null' receiver and is dropped.
 route:
 
-  # The labels by which incoming alerts are grouped together. For example,
-  # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
-  # be batched into a single group.
-  group_by: ['alertname', 'cluster', 'service']
-
-  # When a new group of alerts is created by an incoming alert, wait at
-  # least 'group_wait' to send the initial notification.
+  # Group per-alert and per-host so one host's issue is its own notification
+  # rather than being collapsed with every other host firing the same alert.
+  group_by: ['alertname', 'instance']
   group_wait: 30s
-
-  # When the first notification was sent, wait 'group_interval' to send a batch
-  # of new alerts that started firing for that group.
   group_interval: 5m
-
-  # If an alert has successfully been sent, wait 'repeat_interval' to
-  # resend them.
-  repeat_interval: 2h
-
-  # A default null receiver; active receivers are configured as child routes
+  repeat_interval: 4h
   receiver: 'null'
 {% if monitoring_server_smtp_enabled or monitoring_server_slack_enabled %}
   routes:
-{% if monitoring_server_smtp_enabled %}
-    - receiver: mirsg-admin-email
-      continue: true
+    # Urgent, user-impacting: notify fast, remind every few hours.
+    - matchers:
+        - severity="critical"
+      receiver: mirsg-critical
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 4h
+
+    # Act-soon: batch a little, remind roughly once a day.
+    - matchers:
+        - severity="warning"
+      receiver: mirsg-warning
+      group_wait: 1m
+      group_interval: 10m
+      repeat_interval: 24h
+
+    # Awareness only: notify once, effectively no reminders.
+    - matchers:
+        - severity="info"
+      receiver: mirsg-info
+      group_wait: 5m
+      group_interval: 30m
+      repeat_interval: 168h
 {% endif %}
-{% if monitoring_server_slack_enabled %}
-    - receiver: mirsg-slack
-      continue: true
-{% endif %}
-{% endif %}
+
+# Suppress lower-severity noise for a host while a higher severity is firing
+# for the same instance (e.g. a down host shouldn't also page CPU/disk warnings,
+# and the most-severe SSL-expiry window silences the earlier ones).
+inhibit_rules:
+  - source_matchers:
+      - severity="critical"
+    target_matchers:
+      - severity=~"warning|info"
+    equal: ['instance']
+  - source_matchers:
+      - severity="warning"
+    target_matchers:
+      - severity="info"
+    equal: ['instance']
 
 receivers:
   - name: 'null'
+{% if monitoring_server_smtp_enabled or monitoring_server_slack_enabled %}
+
+  # Critical -> Slack and email.
+  - name: 'mirsg-critical'
 {% if monitoring_server_smtp_enabled %}
-  - name: 'mirsg-admin-email'
     email_configs:
-      - to: {{ monitoring_server_notification_email }}
+      {{ email_config() | trim | indent(6) }}
 {% endif %}
 {% if monitoring_server_slack_enabled %}
-  - name: 'mirsg-slack'
     slack_configs:
-      - api_url: "{{ monitoring_server_slack_webhook_url }}"
-        channel: "{{ monitoring_server_slack_channel }}"
-        # Note: when using an incoming webhook, the target channel is set in Slack
-        # when the webhook is created. This field is required by the schema but
-        # does not override the webhook's channel.
-        send_resolved: true
-        title: '{% raw %}{{ template "slack.title" . }}{% endraw %}'
-        text: '{% raw %}{{ template "slack.text" . }}{% endraw %}'
+      {{ slack_config() | trim | indent(6) }}
+{% endif %}
+
+  # Warning -> Slack (falls back to email if Slack is disabled).
+  - name: 'mirsg-warning'
+{% if monitoring_server_slack_enabled %}
+    slack_configs:
+      {{ slack_config() | trim | indent(6) }}
+{% elif monitoring_server_smtp_enabled %}
+    email_configs:
+      {{ email_config() | trim | indent(6) }}
+{% endif %}
+
+  # Info -> Slack only (silent if Slack is disabled).
+  - name: 'mirsg-info'
+{% if monitoring_server_slack_enabled %}
+    slack_configs:
+      {{ slack_config() | trim | indent(6) }}
+{% endif %}
 {% endif %}

--- a/roles/monitoring_server/templates/alertmanager.yml.j2
+++ b/roles/monitoring_server/templates/alertmanager.yml.j2
@@ -11,9 +11,16 @@
   # when the webhook is created. This field is required by the schema but
   # does not override the webhook's channel.
   send_resolved: true
-  color: '{% raw %}{{ if eq .CommonLabels.severity "critical" }}danger{{ else if eq .CommonLabels.severity "warning" }}warning{{ else }}good{{ end }}{% endraw %}'
+  color: '{% raw %}{{ template "slack.color" . }}{% endraw %}'
   title: '{% raw %}{{ template "slack.title" . }}{% endraw %}'
   text: '{% raw %}{{ template "slack.text" . }}{% endraw %}'
+  actions:
+    - type: button
+      text: 'Query :mag:'
+      url: '{% raw %}{{ (index .Alerts 0).GeneratorURL }}{% endraw %}'
+    - type: button
+      text: 'Silence :no_bell:'
+      url: '{% raw %}{{ template "__alert_silence_link" . }}{% endraw %}'
 {% endmacro %}
 {%- macro email_config() %}
 - to: {{ monitoring_server_notification_email }}

--- a/roles/monitoring_server/templates/prometheus_rules.yml.j2
+++ b/roles/monitoring_server/templates/prometheus_rules.yml.j2
@@ -1,12 +1,33 @@
 groups:
   - name: tls-expiry
     rules:
+      # Escalating windows on the same condition; Alertmanager inhibition
+      # (equal: instance) ensures only the most-severe firing window notifies.
       - alert: SSLCertExpiringSoon
-        expr: probe_ssl_earliest_cert_expiry - time() < 60 * 60 * 24 * 14
-        for: 2m
+        expr: probe_ssl_earliest_cert_expiry - time() < 60 * 60 * 24 * 21
+        for: 1h
+        labels:
+          severity: info
+        annotations:
+          summary: "TLS certificate expiring soon (instance {{ $labels.instance }})"
+          description: "TLS certificate will expire in {{ $value | humanizeDuration }} (instance {{ $labels.instance }})"
+
+      - alert: SSLCertExpiringSoon
+        expr: probe_ssl_earliest_cert_expiry - time() < 60 * 60 * 24 * 7
+        for: 1h
         labels:
           severity: warning
         annotations:
+          summary: "TLS certificate expiring soon (instance {{ $labels.instance }})"
+          description: "TLS certificate will expire in {{ $value | humanizeDuration }} (instance {{ $labels.instance }})"
+
+      - alert: SSLCertExpiringSoon
+        expr: probe_ssl_earliest_cert_expiry - time() < 60 * 60 * 24 * 2
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "TLS certificate expiring imminently (instance {{ $labels.instance }})"
           description: "TLS certificate will expire in {{ $value | humanizeDuration }} (instance {{ $labels.instance }})"
 
   - name: down-detector
@@ -23,7 +44,7 @@ groups:
         expr: up == 0
         for: 5m
         labels:
-          severity: high
+          severity: critical
         annotations:
           summary: "{{ $labels.job }} instance {{ $labels.instance }} down"
           description: "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes."
@@ -41,7 +62,7 @@ groups:
 
       - alert: CpuLoadHigh
         expr: 100 - avg by(instance)(rate(node_cpu_seconds_total{mode="idle"}[10m]))*100 > 90
-        for: 0m
+        for: 15m
         labels:
           severity: warning
         annotations:
@@ -57,9 +78,18 @@ groups:
           summary: Instance filestore disk space low (Instance:{{ $labels.instance }})
           description: "The used space of the mounted filestore (mountpoint:{{ $labels.mountpoint }}) is more than 90%, value: {{ $value }}%"
 
+      - alert: FilesystemFull
+        expr: 100 - node_filesystem_free_bytes{mountpoint!~"/*|/boot.*|/run.*"}/node_filesystem_size_bytes*100 > 97
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: Instance filestore almost full (Instance:{{ $labels.instance }})
+          description: "The used space of the mounted filestore (mountpoint:{{ $labels.mountpoint }}) is more than 97%, value: {{ $value }}%"
+
       - alert: InodeUsageHigh
         expr: 100 - node_filesystem_files_free/node_filesystem_files*100 > 90
-        for: 0m
+        for: 10m
         labels:
           severity: warning
         annotations:

--- a/roles/monitoring_server/templates/prometheus_rules.yml.j2
+++ b/roles/monitoring_server/templates/prometheus_rules.yml.j2
@@ -37,7 +37,7 @@ groups:
           severity: warning
         annotations:
           summary: Instance memory usage high (Instance:{{ $labels.instance }})
-          description: "Instance memory usage more than 90% within 5 minutes, value:{{ $labels.value }}%"
+          description: "Instance memory usage more than 90% within 5 minutes, value:{{ $value }}%"
 
       - alert: CpuLoadHigh
         expr: 100 - avg by(instance)(rate(node_cpu_seconds_total{mode="idle"}[10m]))*100 > 90
@@ -46,7 +46,7 @@ groups:
           severity: warning
         annotations:
           summary: Instance cpu load high (Instance:{{ $labels.instance }})
-          description: "Instance cpu load more than 90% within 10 minutes, value: {{ $labels.value }}%"
+          description: "Instance cpu load more than 90% within 10 minutes, value: {{ $value }}%"
 
       - alert: FilesystemFull
         expr: 100 - node_filesystem_free_bytes{mountpoint!~"/*|/boot.*|/run.*"}/node_filesystem_size_bytes*100 > 90
@@ -55,7 +55,7 @@ groups:
           severity: warning
         annotations:
           summary: Instance filestore disk space low (Instance:{{ $labels.instance }})
-          description: "The used space of the mounted filestore (mountpoint:{{ $labels.mountpoint }}) is more than 90%, value: {{ $labels.value }}%"
+          description: "The used space of the mounted filestore (mountpoint:{{ $labels.mountpoint }}) is more than 90%, value: {{ $value }}%"
 
       - alert: InodeUsageHigh
         expr: 100 - node_filesystem_files_free/node_filesystem_files*100 > 90
@@ -64,4 +64,4 @@ groups:
           severity: warning
         annotations:
           summary: Instance inode usage high (Instance:{{ $labels.instance }})
-          description: "The used file nodes(inodes) of the filesystem(filesystem:{{ $labels.mountpoint }}) is more than 90%, value: {{ $labels.value }}%"
+          description: "The used file nodes(inodes) of the filesystem(filesystem:{{ $labels.mountpoint }}) is more than 90%, value: {{ $value }}%"

--- a/roles/monitoring_server/templates/slack.tmpl
+++ b/roles/monitoring_server/templates/slack.tmpl
@@ -1,0 +1,13 @@
+{{ define "slack.title" -}}
+[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}
+{{- end }}
+
+{{ define "slack.text" -}}
+{{ range .Alerts -}}
+*Alert:* {{ .Annotations.summary }}{{ if .Labels.severity }} - `{{ .Labels.severity }}`{{ end }}
+*Description:* {{ .Annotations.description }}
+*Details:*
+{{ range .Labels.SortedPairs }}    • *{{ .Name }}:* `{{ .Value }}`
+{{ end }}
+{{ end -}}
+{{- end }}

--- a/roles/monitoring_server/templates/slack.tmpl
+++ b/roles/monitoring_server/templates/slack.tmpl
@@ -1,13 +1,66 @@
-{{ define "slack.title" -}}
-[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}
+{{/* Alertmanager silence link pre-filled with the group's common labels. */}}
+{{ define "__alert_silence_link" -}}
+    {{ .ExternalURL }}/#/silences/new?filter=%7B
+    {{- range .CommonLabels.SortedPairs -}}
+        {{- if ne .Name "alertname" -}}
+            {{- .Name }}%3D"{{- .Value -}}"%2C%20
+        {{- end -}}
+    {{- end -}}
+    alertname%3D"{{- .CommonLabels.alertname -}}"%7D
 {{- end }}
 
+{{/* Human-readable severity line. */}}
+{{ define "__alert_severity" -}}
+    {{- if eq .CommonLabels.severity "critical" -}}
+    *Severity:* `Critical`
+    {{- else if eq .CommonLabels.severity "warning" -}}
+    *Severity:* `Warning`
+    {{- else if eq .CommonLabels.severity "info" -}}
+    *Severity:* `Info`
+    {{- else -}}
+    *Severity:* :question: {{ .CommonLabels.severity }}
+    {{- end }}
+{{- end }}
+
+{{/* Title of the Slack alert. */}}
+{{ define "slack.title" -}}
+  [{{ .Status | toUpper -}}
+  {{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{- end -}}
+  ] {{ .CommonLabels.alertname }}
+{{- end }}
+
+{{/* Colour of the Slack attachment (the coloured line beside the alert). */}}
+{{ define "slack.color" -}}
+    {{ if eq .Status "firing" -}}
+        {{ if eq .CommonLabels.severity "warning" -}}
+            warning
+        {{- else if eq .CommonLabels.severity "critical" -}}
+            danger
+        {{- else -}}
+            #439FE0
+        {{- end -}}
+    {{ else -}}
+    good
+    {{- end }}
+{{- end }}
+
+{{/* Body of the Slack alert. */}}
 {{ define "slack.text" -}}
-{{ range .Alerts -}}
-*Alert:* {{ .Annotations.summary }}{{ if .Labels.severity }} - `{{ .Labels.severity }}`{{ end }}
-*Description:* {{ .Annotations.description }}
-*Details:*
-{{ range .Labels.SortedPairs }}    • *{{ .Name }}:* `{{ .Value }}`
-{{ end }}
-{{ end -}}
+    {{ template "__alert_severity" . }}
+    {{- if (index .Alerts 0).Annotations.summary }}
+    {{- "\n" -}}
+    *Summary:* {{ (index .Alerts 0).Annotations.summary }}
+    {{- end }}
+    {{ range .Alerts }}
+        {{- if .Annotations.description }}
+        {{- "\n" -}}
+        {{ .Annotations.description }}
+        {{- "\n" -}}
+        {{- end }}
+        {{- if .Annotations.message }}
+        {{- "\n" -}}
+        {{ .Annotations.message }}
+        {{- "\n" -}}
+        {{- end }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
This pull request makes several improvements to the monitoring server's alerting and notification system, focusing on more actionable and informative alerting, improved Slack integration, and better notification routing and suppression. 

The changes include a complete overhaul of the Alertmanager configuration to support severity-based routing and inhibition, new and improved Slack notification templates, and enhancements to Prometheus alert rules for clearer severity and escalation. 

**Alertmanager configuration and notification routing:**

- Rewrote `alertmanager.yml.j2` to use severity-based routing (`critical`, `warning`, `info`) with custom notification intervals and fallback logic, and added inhibition rules to suppress lower-severity alerts when higher-severity ones are firing for the same instance.
- Introduced reusable Jinja macros for Slack and email configs, simplifying receiver definitions and ensuring consistent formatting.

**Slack notification enhancements:**

- Added a complete Slack template (`slack.tmpl`) featuring custom title, color, severity lines, silence link, and improved formatting for alert details.
- Updated the deployment to always provision the Slack template and its directory when Slack notifications are enabled.

**Prometheus alert rule improvements:**

- Refactored TLS expiry alerts to use three severity levels (`info`, `warning`, `critical`) with escalating windows, and ensured only the most severe alert is notified via Alertmanager inhibition.
- Adjusted severity labels for instance down alerts (`high` → `critical`) and improved consistency and accuracy of alert descriptions, including using `$value` instead of `$labels.value`. [[1]](diffhunk://#diff-86f149716646a86b790412e9faa907b0821d66af9132726d2ad5f667a1b5e769L26-R47) [[2]](diffhunk://#diff-86f149716646a86b790412e9faa907b0821d66af9132726d2ad5f667a1b5e769L40-R70) [[3]](diffhunk://#diff-86f149716646a86b790412e9faa907b0821d66af9132726d2ad5f667a1b5e769L58-R97)
- Added a new `FilesystemFull` alert for >97% disk usage with `critical` severity and appropriate notification timing.

**Deployment and configuration changes:**

- Updated Prometheus's `web.external-url` to use the correct public URL, ensuring links in notifications work as expected.
- Ensured Alertmanager is restarted when its configuration or templates change, and added a handler to do so. [[1]](diffhunk://#diff-65e69d1890fddb4b67fda07980a95e92f856d997a60b3a2fd80feb7aa343c49cR20-R25) [[2]](diffhunk://#diff-a55191acabff70302c92fe4f39aad1e06abcb714a5f1d8b5c781d7196d654466R19-R42)