### PR TITLE
Upgrade default postgres version

### DIFF
--- a/playbooks/molecule/resources/xnat/inventory/group_vars/all/common.yml
+++ b/playbooks/molecule/resources/xnat/inventory/group_vars/all/common.yml
@@ -12,8 +12,8 @@ postgresql_use_ssl: true
 # Set this to true if selinux is enabled on the hosting OS
 selinux_enabled: false
 
-# XNAT supports PostgreSQL 11-14
-postgresql_version: 14
+# XNAT supports PostgreSQL 14-18
+postgresql_version: 18
 
 java_keystore:
   keystore_pass: "{{ vault_keystore_password }}"

--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults for mirsg.postgresql
-postgresql_version: 14
+postgresql_version: 18
 postgresql_service_name: postgresql-{{ postgresql_version }}
 postgresql_package_name: postgresql{{ postgresql_version | replace('.', '') }}
 postgresql_bin_directory: /usr/pgsql-{{ postgresql_version }}/bin

--- a/roles/postgresql_upgrade/molecule/resources/inventory/group_vars/all.yml
+++ b/roles/postgresql_upgrade/molecule/resources/inventory/group_vars/all.yml
@@ -16,7 +16,7 @@ postgresql_connection:
   subnet_mask: 255.255.255.255
 
 postgreql_upgrade_current_version: 14
-postgreql_upgrade_new_version: 15
+postgreql_upgrade_new_version: 18
 postgresql_upgrade_data_dir:
   "{{ external_storage_drive }}/pgsql/{{ postgreql_upgrade_new_version }}/data"
 postgresql_upgrade_scripts_dir:


### PR DESCRIPTION
Fixes #231 

Upgrade default postgres version from 14 to 18 for:

- the `postgres` role
- `install_xnat` playbook

Keep `postgres_version` the same for the `install_omero` playbook