### PR TITLE
update monitoring_server_web_group handling in tasks

### DIFF
--- a/roles/monitoring_server/defaults/main.yml
+++ b/roles/monitoring_server/defaults/main.yml
@@ -6,6 +6,7 @@ monitoring_server_uid: 595
 monitoring_server_cert_owner: root
 monitoring_server_cert_group: root
 monitoring_server_storage_root: /data/monitoring
+monitoring_server_web_group: web
 
 # mirsg.monitoring_server CA and server certificate
 monitoring_server_certificate_cache_directory:

--- a/roles/monitoring_server/tasks/main.yml
+++ b/roles/monitoring_server/tasks/main.yml
@@ -12,12 +12,13 @@
 - name: Find web servers in `monitoring_client` group
   ansible.builtin.set_fact:
     # Get any hosts in the `monitoring_client` that are
-    # also in the `web` group
+    # also in the group named by `monitoring_server_web_group`
     monitoring_server_web_clients: >
       {{ query('inventory_hostnames', ansible_limit | default('')) |
-      intersect(groups['monitoring_client']) | intersect(groups['web']) |
-      map('extract', hostvars, monitoring_server_hostname_extractor) |
-      map('regex_replace', '^', 'https://') }}
+      intersect(groups['monitoring_client']) |
+      intersect(groups.get(monitoring_server_web_group, [])) | map('extract',
+      hostvars, monitoring_server_hostname_extractor) | map('regex_replace',
+      '^', 'https://') }}
   failed_when: monitoring_server_web_clients | length == 0
 
 - name: Add monitoring_server group


### PR DESCRIPTION
The monitoring roles identifiedn application web servers by seeing if they were in a hardcoded "web" group. However our current setup puts the application servers into "omero" and "xnat" groups. This PR lets us define what the application server group is called, and has "web" as the default.