### PR TITLE
Install Java from Adoptium

### DIFF
--- a/playbooks/group_vars/xnat.yml
+++ b/playbooks/group_vars/xnat.yml
@@ -64,7 +64,7 @@ postgresql_client_ssl_certificate:
   cache_filename: "{{ database_client_certificate_cache_filename }}" # where to store the client certificate in cache
 
 java:
-  keystore_path: /usr/lib/jvm/jre/lib/security/cacerts/
+  keystore_path: /etc/pki/java/cacerts
 
 ldap_ca_cert_file_on_client: "{{ xnat.install_downloads }}/certs/ldap-ca.cert"
 

--- a/playbooks/install_omero.yml
+++ b/playbooks/install_omero.yml
@@ -36,7 +36,7 @@
         (ansible_distribution_major_version == '8')
     - role: mirsg.infrastructure.install_java
       vars:
-        java_package: java-11-openjdk
+        java_major_version: 11
       when:
         (ansible_os_family | lower == 'redhat') and
         (ansible_distribution_major_version == '9')

--- a/roles/install_java/README.md
+++ b/roles/install_java/README.md
@@ -1,16 +1,21 @@
 # Ansible Role: mirsg.infrastructure.install_java
 
-A role to install and configure Java.
+A role to install and configure Java using
+[Adoptium's Eclipse Temurin](https://adoptium.net/).
 
 ## Role Variables
 
 `java_profile_d`: Defaults to "/etc/profile.d".
 
-`java_home`: Defaults to "/usr/lib/jvm/jre".
+`java_major_version`: The major version of Java to install. Defaults to `8`.
 
-`java_package`: Defaults to "java-1.8.0".
+`java_package`: The Eclipse Temurin package name, derived from
+`java_major_version` (e.g. `temurin-8-jdk`).
 
-`java_package_version`: Defaults to "devel".
+`java_home`: The JDK's install directory. Defaults to `/usr/lib/jvm/jre`.
+
+`java_adoptium_repo_baseurl` / `java_adoptium_repo_gpgkey`: The Temurin yum
+repository and GPG key used to install the package.
 
 ## Example Playbook
 

--- a/roles/install_java/defaults/main.yml
+++ b/roles/install_java/defaults/main.yml
@@ -1,5 +1,12 @@
 ---
 java_profile_d: /etc/profile.d
+
+java_major_version: 8
+java_package: temurin-{{ java_major_version }}-jdk
 java_home: /usr/lib/jvm/jre
-java_package: java-1.8.0-openjdk
-java_package_version: devel
+
+java_adoptium_repo_baseurl:
+  https://packages.adoptium.net/artifactory/rpm/rhel/{{
+  ansible_facts['distribution_major_version'] }}/{{
+  ansible_facts['architecture'] }}
+java_adoptium_repo_gpgkey: https://packages.adoptium.net/artifactory/api/gpg/key/public

--- a/roles/install_java/tasks/main.yml
+++ b/roles/install_java/tasks/main.yml
@@ -35,40 +35,29 @@
     path: "{{ java_package_info.stat.lnk_source }}/jre"
   register: java_jre
 
+- name: Set the default java version - {{ java_package_info.stat.lnk_source }}
+  community.general.alternatives:
+    name: java
+    link: /usr/bin/java
+    path: "{{ java_package_info.stat.lnk_source }}/bin/java"
+    state: selected
+
 - name: >-
-    Configure alternatives for Java 8-style layout (separate bin/ and jre/) - {{
+    Set the default JRE directory (Java 8-style layout) - {{
     java_package_info.stat.lnk_source }}
+  community.general.alternatives:
+    name: jre
+    link: /usr/lib/jvm/jre
+    path: "{{ java_package_info.stat.lnk_source }}/jre"
+    state: selected
   when: java_jre.stat.exists
-  block:
-    - name: Set the default java version
-      community.general.alternatives:
-        name: java
-        link: /usr/bin/java
-        path: "{{ java_package_info.stat.lnk_source }}/jre/bin/java"
-        state: selected
-
-    - name: Set the default JRE directory
-      community.general.alternatives:
-        name: jre
-        link: /usr/lib/jvm/jre
-        path: "{{ java_package_info.stat.lnk_source }}/jre"
-        state: selected
 
 - name: >-
-    Configure alternatives for merged JDK/JRE layout (Java 9+) - {{
+    Set the default JRE directory (merged JDK/JRE layout, Java 9+) - {{
     java_package_info.stat.lnk_source }}
+  community.general.alternatives:
+    name: jre
+    link: /usr/lib/jvm/jre
+    path: "{{ java_package_info.stat.lnk_source }}"
+    state: selected
   when: not java_jre.stat.exists
-  block:
-    - name: Set the default java version
-      community.general.alternatives:
-        name: java
-        link: /usr/bin/java
-        path: "{{ java_package_info.stat.lnk_source }}/bin/java"
-        state: selected
-
-    - name: Set the default JRE directory
-      community.general.alternatives:
-        name: jre
-        link: /usr/lib/jvm/jre
-        path: "{{ java_package_info.stat.lnk_source }}"
-        state: selected

--- a/roles/install_java/tasks/main.yml
+++ b/roles/install_java/tasks/main.yml
@@ -1,7 +1,21 @@
 ---
+- name: Add Eclipse Temurin (Adoptium) repository GPG key
+  ansible.builtin.rpm_key:
+    key: "{{ java_adoptium_repo_gpgkey }}"
+    state: present
+
+- name: Add Eclipse Temurin (Adoptium) yum repository
+  ansible.builtin.yum_repository:
+    name: adoptium
+    description: Eclipse Temurin (Adoptium)
+    baseurl: "{{ java_adoptium_repo_baseurl }}"
+    gpgcheck: true
+    gpgkey: "{{ java_adoptium_repo_gpgkey }}"
+    enabled: true
+
 - name: Ensure correct Java version is installed - {{ java_package }}
   ansible.builtin.package:
-    name: "{{ java_package }}-{{ java_package_version }}"
+    name: "{{ java_package }}"
     state: installed
 
 - name: Set JAVA_HOME through shell script
@@ -21,16 +35,40 @@
     path: "{{ java_package_info.stat.lnk_source }}/jre"
   register: java_jre
 
-- name: Set the default java version - {{ java_package_info.stat.lnk_source }}
-  community.general.alternatives:
-    name: java
-    path: "{{ java_package_info.stat.lnk_source }}/jre/bin/java"
-    state: selected
+- name: >-
+    Configure alternatives for Java 8-style layout (separate bin/ and jre/) - {{
+    java_package_info.stat.lnk_source }}
   when: java_jre.stat.exists
+  block:
+    - name: Set the default java version
+      community.general.alternatives:
+        name: java
+        link: /usr/bin/java
+        path: "{{ java_package_info.stat.lnk_source }}/jre/bin/java"
+        state: selected
 
-- name: Set the default java version - {{ java_package_info.stat.lnk_source }}
-  community.general.alternatives:
-    name: java
-    path: "{{ java_package_info.stat.lnk_source }}/bin/java"
-    state: selected
+    - name: Set the default JRE directory
+      community.general.alternatives:
+        name: jre
+        link: /usr/lib/jvm/jre
+        path: "{{ java_package_info.stat.lnk_source }}/jre"
+        state: selected
+
+- name: >-
+    Configure alternatives for merged JDK/JRE layout (Java 9+) - {{
+    java_package_info.stat.lnk_source }}
   when: not java_jre.stat.exists
+  block:
+    - name: Set the default java version
+      community.general.alternatives:
+        name: java
+        link: /usr/bin/java
+        path: "{{ java_package_info.stat.lnk_source }}/bin/java"
+        state: selected
+
+    - name: Set the default JRE directory
+      community.general.alternatives:
+        name: jre
+        link: /usr/lib/jvm/jre
+        path: "{{ java_package_info.stat.lnk_source }}"
+        state: selected

--- a/roles/ldap/README.md
+++ b/roles/ldap/README.md
@@ -1,23 +1,27 @@
 # Ansible Role: mirsg.infrastructure.ldap
 
 This Ansible role copies an LDAP cert from the controller to a remote machine
-and adds it to the Java keystore. Make sure to install Java before running this
-role.
+and adds it to the Java keystore.
+
+## Dependencies
+
+The `ca-certificates` package must be installed on the remote host as it bundles
+the certificates used by this role (`/etc/pki/java/cacerts`).
 
 ## Role Variables
 
 The following variables can be customized to suit your environment. Default
 values are sourced from the `defaults` folder.
 
-| Variable                   | Description                                                        | Default Value                            |
-| -------------------------- | ------------------------------------------------------------------ | ---------------------------------------- |
-| `ldap_cert_dir`            | Directory on the remote where the cert will be copied.             | `/root/certs`                            |
-| `ldap_cert_owner`          | OS user on the remote that will have ownership of the copied cert. | `root`                                   |
-| `ldap_cert_owner_group`    | OS group on the remote.                                            | `root`                                   |
-| `ldap_ca_cert_path`        | Path to the cert on the Ansible controller.                        | N/A (must be provided by the user)       |
-| `ldap_java_keystore_path`  | Path in the remote keystore to the cert.                           | `/usr/lib/jvm/jre/lib/security/cacerts/` |
-| `ldap_java_keystore_pass`  | Password for the remote keystore.                                  | N/A (must be provided by the user)       |
-| `ldap_java_keystore_alias` | Name of the cert in the remote keystore.                           | `ldap-ca`                                |
+| Variable                   | Description                                                        | Default Value                      |
+| -------------------------- | ------------------------------------------------------------------ | ---------------------------------- |
+| `ldap_cert_dir`            | Directory on the remote where the cert will be copied.             | `/root/certs`                      |
+| `ldap_cert_owner`          | OS user on the remote that will have ownership of the copied cert. | `root`                             |
+| `ldap_cert_owner_group`    | OS group on the remote.                                            | `root`                             |
+| `ldap_ca_cert_path`        | Path to the cert on the Ansible controller.                        | N/A (must be provided by the user) |
+| `ldap_java_keystore_path`  | Path in the remote keystore to the cert.                           | `/etc/pki/java/cacerts`            |
+| `ldap_java_keystore_pass`  | Password for the remote keystore.                                  | N/A (must be provided by the user) |
+| `ldap_java_keystore_alias` | Name of the cert in the remote keystore.                           | `ldap-ca`                          |
 
 ## Usage
 
@@ -31,7 +35,7 @@ To use this role, include it in your playbook as follows:
       vars:
         ldap_ca_cert_path:
           "{{ lookup('env', 'HOME') }}/ansible_persistent_files/ldap/ca.pem"
-        ldap_java_keystore_path: /usr/lib/jvm/jre/lib/security/cacerts/
+        ldap_java_keystore_path: /etc/pki/java/cacerts
         ldap_java_keystore_pass: keystore_password
         ldap_java_keystore_alias: ldap-ca
 ```

--- a/roles/ldap/molecule/resources/converge.yml
+++ b/roles/ldap/molecule/resources/converge.yml
@@ -9,6 +9,6 @@
       vars:
         ldap_ca_cert_path:
           "{{ lookup('env', 'HOME') }}/ansible_persistent_files/ldap/ca.pem"
-        ldap_java_keystore_path: /usr/lib/jvm/jre/lib/security/cacerts/
+        ldap_java_keystore_path: /etc/pki/java/cacerts
         ldap_java_keystore_pass: "{{ vault_java_keystore_password }}"
         ldap_java_keystore_alias: ldap-ca

--- a/roles/tomcat/molecule/resources/prepare.yml
+++ b/roles/tomcat/molecule/resources/prepare.yml
@@ -15,6 +15,4 @@
         state: present
   roles:
     - role: mirsg.infrastructure.install_java
-      java_package:
-        "{{ 'java-11-openjdk' if 'tomcat10' in group_names else
-        'java-1.8.0-openjdk'}}"
+      java_major_version: "{{ 11 if 'tomcat10' in group_names else 8 }}"


### PR DESCRIPTION
Fixes #232 

- update the `install_java` role to use the Adoptium distribution (Eclipse Temurin)
- the default java version is kept the same (8)
- remove `java_package` variable and replace it with `java_major_version`
- set the default JRE directory (using `community.general.alternatives`). openjdk does this automatically, but we need to do it manually for Temurin
- change the keystore path to `/etc/pki/java/cacerts` (which is provided by `ca-certificates`). The previous path was actually a symlink to this one anyway